### PR TITLE
scan inbox every 10min, also cleanup server start & stop

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -1,7 +1,7 @@
 {
     "server": {"host": "0.0.0.0", "port": 8000, "url": "http://localhost:8000"},
     "datastore": {"name": "connect", "key": "k"},
-    "webknossos": {"url": "http://localhost:9000", "ping_interval_minutes": 10},
+    "webknossos": {"url": "http://localhost:9000"},
     "backends": {"neuroglancer": {}},
     "datasets_path": "data/datasets.json"
 }

--- a/wkconnect/utils/scheduler.py
+++ b/wkconnect/utils/scheduler.py
@@ -1,0 +1,27 @@
+import asyncio
+from functools import wraps
+from typing import Any, Awaitable, Callable, TypeVar, cast
+
+T = TypeVar("T", bound=Callable[..., Awaitable[Any]])
+
+
+def repeat_every_seconds(
+    interval_seconds: float, initial_call: bool = True
+) -> Callable[[T], T]:
+    def decorator(f: T) -> T:
+        @wraps(f)
+        async def decorator(*args: Any, **kwargs: Any) -> Any:
+            if initial_call:
+                await f(*args, **kwargs)
+            while True:
+                try:
+                    await asyncio.sleep(interval_seconds)
+                except asyncio.CancelledError:
+                    break
+                await f(*args, **kwargs)
+
+        # cast necessary, see
+        # https://github.com/python/mypy/issues/1927
+        return cast(T, decorator)
+
+    return decorator


### PR DESCRIPTION
This re-reports all datasets every 10 minutes, just in case somebody changes the datasets.json, or wk was not available at startup. On that note: wkconnect now starts without wk being up, but warns appropriately. Also stopping the server now does not produce unnecessary errors anymore.