### PR TITLE
BOSS: add caching

### DIFF
--- a/wkconnect/__main__.py
+++ b/wkconnect/__main__.py
@@ -94,9 +94,9 @@ class CustomErrorHandler(ErrorHandler):
             return super().default(request, exception)
         else:
             message = f"{type(exception).__name__} in webknossos-connect."
-            message_json = {
-                "messages": [{"error": message, "chain": [traceback.format_exc()]}]
-            }
+            stack = traceback.format_exc()
+            message_json = {"messages": [{"error": message, "chain": [stack]}]}
+            logger.error(stack)
             return response.json(message_json, status=500)
 
 

--- a/wkconnect/backends/backend.py
+++ b/wkconnect/backends/backend.py
@@ -1,11 +1,13 @@
 from abc import ABCMeta, abstractmethod
-from typing import Dict
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 from aiohttp import ClientSession
 
-from ..utils.types import JSON, Vec3D
+from ..utils.types import JSON, Box3D, Vec3D
 from ..webknossos.models import DataSource as WKDataSource
+
+Chunk = Tuple[Box3D, np.ndarray]
 
 
 class DatasetInfo(metaclass=ABCMeta):
@@ -32,6 +34,27 @@ class Backend(metaclass=ABCMeta):
     ) -> DatasetInfo:
         pass
 
+    def _chunks(self, box: Box3D, frame: Box3D, chunk_size: Vec3D) -> Iterable[Box3D]:
+        # clip data outside available data
+        inside = box.intersect(frame)
+
+        # align request to chunks
+        aligned = (inside - frame.left).div(chunk_size) * chunk_size + frame.left
+
+        for chunk_offset in aligned.range(offset=chunk_size):
+            # The size is at most chunk_size but capped to fit the dataset:
+            capped_chunk_size = chunk_size.pairmin(frame.size() - chunk_offset)
+            yield Box3D.from_size(chunk_offset, capped_chunk_size)
+
+    def _cutout(self, chunks: List[Chunk], box: Box3D) -> np.ndarray:
+        result = np.zeros(box.size(), dtype=chunks[0][1].dtype, order="F")
+        for chunk_box, chunk_data in chunks:
+            inner = chunk_box.intersect(box)
+            result[(inner - box.left).np_slice()] = chunk_data[
+                (inner - chunk_box.left).np_slice()
+            ]
+        return result
+
     @abstractmethod
     async def read_data(
         self,
@@ -40,7 +63,7 @@ class Backend(metaclass=ABCMeta):
         zoom_step: int,
         wk_offset: Vec3D,
         shape: Vec3D,
-    ) -> np.ndarray:
+    ) -> Optional[np.ndarray]:
         """
         Read voxels from the backend.
 

--- a/wkconnect/backends/boss/backend.py
+++ b/wkconnect/backends/boss/backend.py
@@ -144,7 +144,7 @@ class Boss(Backend):
             data = np.frombuffer(byte_data, dtype=">u2")
         else:
             data = np.frombuffer(byte_data, dtype=channel.datatype)
-        return data.astype(channel.wk_datatype()).reshape(box.size(), order="F")
+        return data.astype(channel.wk_datatype()).reshape(shape, order="F")
 
     def clear_dataset_cache(self, dataset: DatasetInfo) -> None:
         pass

--- a/wkconnect/backends/boss/models.py
+++ b/wkconnect/backends/boss/models.py
@@ -14,7 +14,6 @@ from ..backend import DatasetInfo
 class Channel:
     datatype: str
     resolutions: Tuple[Vec3D, ...]
-    cuboid_size: Vec3D
     type: str
 
     def __post_init__(self) -> None:

--- a/wkconnect/backends/neuroglancer/backend.py
+++ b/wkconnect/backends/neuroglancer/backend.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, cast
+from typing import Any, Callable, Dict, Optional, Tuple, cast
 
 import jpeg4py as jpeg
 import numpy as np
@@ -10,11 +10,10 @@ import compressed_segmentation
 
 from ...utils.json import from_json
 from ...utils.types import JSON, Box3D, Vec3D
-from ..backend import Backend, DatasetInfo
-from .models import Dataset, Layer, Scale
+from ..backend import Backend, Chunk, DatasetInfo
+from .models import Dataset, Layer
 
 DecoderFn = Callable[[bytes, str, Vec3D, Optional[Vec3D]], np.ndarray]
-Chunk = Tuple[Box3D, np.ndarray]
 
 
 class Neuroglancer(Backend):
@@ -37,6 +36,11 @@ class Neuroglancer(Backend):
         async with await self.http_client.get(info_url) as r:
             response = await r.json()
         layer.update(response)
+        layer["scales"] = sorted(layer["scales"], key=lambda scale: scale["resolution"])
+        min_resolution = Vec3D(*layer["scales"][0]["resolution"])
+        for scale in layer["scales"]:
+            scale["resolution"] = Vec3D(*scale["resolution"]) // min_resolution
+        layer["relative_scale"] = min_resolution
         return (layer_name, from_json(layer, Layer))
 
     async def handle_new_dataset(
@@ -81,20 +85,6 @@ class Neuroglancer(Backend):
             buffer, chunk_size, data_type, block_size, order="F"
         )
 
-    def __chunks(self, box: Box3D, scale: Scale, chunk_size: Vec3D) -> Iterable[Box3D]:
-        # clip data outside available data
-        inside = box.intersect(scale.box())
-
-        # align request to chunks
-        aligned = (inside - scale.voxel_offset).div(
-            chunk_size
-        ) * chunk_size + scale.voxel_offset
-
-        for chunk_offset in aligned.range(offset=chunk_size):
-            # The size is at most chunk_size but capped to fit the dataset:
-            capped_chunk_size = chunk_size.pairmin(scale.size - chunk_offset)
-            yield Box3D.from_size(chunk_offset, capped_chunk_size)
-
     @alru_cache(maxsize=2 ** 12)
     async def __read_chunk(
         self,
@@ -109,32 +99,15 @@ class Neuroglancer(Backend):
         )
         data_url = f"{layer.source}/{scale_key}/{url_coords}"
 
-        try:
-            async with await self.http_client.get(data_url) as r:
-                response_buffer = await r.read()
-        except ClientResponseError:
-            chunk_data = np.zeros(chunk_box.size(), dtype=layer.wk_data_type())
-        else:
-            chunk_data = decoder_fn(
-                response_buffer,
-                layer.data_type,
-                chunk_box.size(),
-                compressed_segmentation_block_size,
-            ).astype(layer.wk_data_type())
+        async with await self.http_client.get(data_url) as r:
+            response_buffer = await r.read()
+        chunk_data = decoder_fn(
+            response_buffer,
+            layer.data_type,
+            chunk_box.size(),
+            compressed_segmentation_block_size,
+        ).astype(layer.wk_data_type())
         return (chunk_box, chunk_data)
-
-    def __cutout(
-        self, chunks: Iterable[Chunk], data_type: str, offset: Vec3D, shape: Vec3D
-    ) -> np.ndarray:
-        result = np.zeros(shape, dtype=data_type, order="F")
-        box = Box3D.from_size(offset, shape)
-        for chunk_box, chunk_data in chunks:
-            inner = chunk_box.intersect(box)
-            result[(inner - offset).np_slice()] = chunk_data[
-                (inner - chunk_box.left).np_slice()
-            ]
-
-        return result
 
     async def read_data(
         self,
@@ -143,38 +116,35 @@ class Neuroglancer(Backend):
         zoom_step: int,
         wk_offset: Vec3D,
         shape: Vec3D,
-    ) -> np.ndarray:
+    ) -> Optional[np.ndarray]:
         neuroglancer_dataset = cast(Dataset, dataset)
         layer = neuroglancer_dataset.layers[layer_name]
-        # TODO add lookup table for scale for efficiency
-
-        def fits_resolution(scale: Scale) -> bool:
-            wk_resolution = scale.resolution // neuroglancer_dataset.scale
-            return max(wk_resolution) == 2 ** zoom_step
-
-        scale = next(scale for scale in layer.scales if fits_resolution(scale))
+        scale = layer.scales[zoom_step]
         decoder = self.decoders[scale.encoding]
 
         # convert to coordinate system of current scale
-        offset = wk_offset * neuroglancer_dataset.scale // scale.resolution
+        offset = wk_offset // scale.resolution
+        box = Box3D.from_size(offset, shape)
 
-        chunk_boxes = self.__chunks(
-            Box3D.from_size(offset, shape), scale, scale.chunk_sizes[0]
-        )
-        chunks = await asyncio.gather(
-            *(
-                self.__read_chunk(
-                    layer,
-                    scale.key,
-                    chunk_box,
-                    decoder,
-                    scale.compressed_segmentation_block_size,
+        chunk_boxes = self._chunks(box, scale.box(), scale.chunk_sizes[0])
+        try:
+            chunks = await asyncio.gather(
+                *(
+                    self.__read_chunk(
+                        layer,
+                        scale.key,
+                        chunk_box,
+                        decoder,
+                        scale.compressed_segmentation_block_size,
+                    )
+                    for chunk_box in chunk_boxes
                 )
-                for chunk_box in chunk_boxes
             )
-        )
+        except ClientResponseError:
+            # will be reported in MISSING-BUCKETS, frontend will retry
+            return None
 
-        return self.__cutout(chunks, layer.wk_data_type(), offset, shape)
+        return self._cutout(chunks, box)
 
     def clear_dataset_cache(self, dataset: DatasetInfo) -> None:
         self.__read_chunk.cache_clear()  # pylint: disable=no-member

--- a/wkconnect/backends/neuroglancer/models.py
+++ b/wkconnect/backends/neuroglancer/models.py
@@ -39,6 +39,7 @@ class Layer:
     data_type: str
     num_channels: int
     scales: Tuple[Scale, ...]
+    relative_scale: Vec3D
     type: str
     # InitVar allows to consume mesh argument in init without storing it
     mesh: InitVar[Any] = None
@@ -51,14 +52,14 @@ class Layer:
         assert self.type in supported_data_types
         assert self.data_type in supported_data_types[self.type]
         assert self.num_channels == 1
+        assert all(
+            max(scale.resolution) == 2 ** i for i, scale in enumerate(self.scales)
+        )
 
     def wk_data_type(self) -> str:
         if self.type == "segmentation":
             return "uint32"
         return self.data_type
-
-    def min_scale(self) -> Scale:
-        return min(self.scales, key=lambda scale: sum(scale.resolution))
 
     def to_webknossos(self, layer_name: str, global_scale: Vec3D) -> WkDataLayer:
         normalized_resolutions = [
@@ -67,7 +68,7 @@ class Layer:
         return WkDataLayer(
             layer_name,
             {"image": "color", "segmentation": "segmentation"}[self.type],
-            self.min_scale().bounding_box(),
+            self.scales[0].bounding_box(),
             normalized_resolutions,
             self.wk_data_type(),
         )
@@ -81,11 +82,9 @@ class Dataset(DatasetInfo):
     scale: Vec3D = field(init=False)
 
     def __post_init__(self) -> None:
-        min_resolution = set(
-            layer.min_scale().resolution for layer in self.layers.values()
-        )
-        assert len(min_resolution) == 1
-        self.scale = next(iter(min_resolution))
+        relative_scale = set(layer.relative_scale for layer in self.layers.values())
+        assert len(relative_scale) == 1
+        self.scale = relative_scale.pop()
 
     def to_webknossos(self) -> WkDataSource:
         return WkDataSource(

--- a/wkconnect/backends/neuroglancer/models.py
+++ b/wkconnect/backends/neuroglancer/models.py
@@ -61,15 +61,12 @@ class Layer:
             return "uint32"
         return self.data_type
 
-    def to_webknossos(self, layer_name: str, global_scale: Vec3D) -> WkDataLayer:
-        normalized_resolutions = [
-            scale.resolution // global_scale for scale in self.scales
-        ]
+    def to_webknossos(self, layer_name: str) -> WkDataLayer:
         return WkDataLayer(
             layer_name,
             {"image": "color", "segmentation": "segmentation"}[self.type],
             self.scales[0].bounding_box(),
-            normalized_resolutions,
+            [scale.resolution for scale in self.scales],
             self.wk_data_type(),
         )
 
@@ -90,7 +87,7 @@ class Dataset(DatasetInfo):
         return WkDataSource(
             WkDataSourceId(self.organization_name, self.dataset_name),
             [
-                layer.to_webknossos(layer_name, self.scale)
+                layer.to_webknossos(layer_name)
                 for layer_name, layer in self.layers.items()
             ],
             self.scale,

--- a/wkconnect/utils/caching.py
+++ b/wkconnect/utils/caching.py
@@ -12,7 +12,7 @@ def atlru_cache(
 ) -> Callable[[T], T]:
     def decorator(f: T) -> T:
         @wraps(f)
-        @alru_cache(maxsize=maxsize, typed=typed)
+        @alru_cache(maxsize=maxsize, typed=typed, cache_exceptions=False)
         async def time_f(*args: Any, **kwargs: Any) -> Any:
             return (time.monotonic(), await f(*args, **kwargs))
 

--- a/wkconnect/utils/types.py
+++ b/wkconnect/utils/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from operator import add, floordiv, mul, sub
+from operator import add, floordiv, mod, mul, sub
 from typing import Any, Callable, Iterator, NamedTuple, Union
 
 import numpy as np
@@ -28,6 +28,9 @@ class Vec3D(NamedTuple):
     def __floordiv__(self, other: Any) -> Vec3D:
         return self._element_wise(other, floordiv)
 
+    def __mod__(self, other: Any) -> Vec3D:
+        return self._element_wise(other, mod)
+
     def ceildiv(self, other: Any) -> Vec3D:
         return (self + other - 1) // other
 
@@ -36,6 +39,14 @@ class Vec3D(NamedTuple):
 
     def pairmin(self, other: Any) -> Vec3D:
         return self._element_wise(other, min)
+
+    @classmethod
+    def zeros(cls) -> Vec3D:
+        return cls(0, 0, 0)
+
+    @classmethod
+    def ones(cls) -> Vec3D:
+        return cls(1, 1, 1)
 
 
 class Box3D(NamedTuple):
@@ -79,7 +90,7 @@ class Box3D(NamedTuple):
     def intersect(self, other: Box3D) -> Box3D:
         return Box3D(self.left.pairmax(other.left), self.right.pairmin(other.right))
 
-    def range(self, offset: Vec3D = Vec3D(1, 1, 1)) -> Iterator[Vec3D]:
+    def range(self, offset: Vec3D = Vec3D.ones()) -> Iterator[Vec3D]:
         for x in range(self.left.x, self.right.x, offset.x):
             for y in range(self.left.y, self.right.y, offset.y):
                 for z in range(self.left.z, self.right.z, offset.z):

--- a/wkconnect/utils/types.py
+++ b/wkconnect/utils/types.py
@@ -96,3 +96,8 @@ class Box3D(NamedTuple):
 # TODO refine this when recursive types are possible:
 # see https://github.com/python/mypy/issues/731
 JSON = Any
+
+
+class HashableDict(dict):
+    def __hash__(self) -> int:
+        return hash(tuple(sorted(self.items())))


### PR DESCRIPTION
This PR:
* ~~makes the BOSS backend cuboid aware, and requests chunks in those sizes~~
* uses caching for data chunks
* adds some refactorings:
  * avoid searching lists in BOSS and neuroglancer backend, using dicts instead
  * ~~moves `_chunks` and `_cutout` to `Backend` baseclass (maybe undoing this, if we don't align to cuboids in BOSS)~~
  * some minor stuff

~~Using the cuboids delayes the arrival of the first chunks heavily, which gives a bad UX
I would rather not use cuboid chunks here, and instead cache the chunks in the size of the incoming requests.~~

fixes #61 