### PR TITLE
boss: allow resolutions that are based on a floating point minimum

### DIFF
--- a/wkconnect/backends/boss/backend.py
+++ b/wkconnect/backends/boss/backend.py
@@ -42,7 +42,7 @@ class Boss(Backend):
             Vec3Df(*i) for i in sorted(downsample_info["voxel_size"].values())
         )
         normalized_resolutions = tuple(
-            (i / resolutions[0]).toVec3D() for i in resolutions
+            (i / resolutions[0]).to_int() for i in resolutions
         )
 
         return (

--- a/wkconnect/backends/neuroglancer/models.py
+++ b/wkconnect/backends/neuroglancer/models.py
@@ -92,5 +92,5 @@ class Dataset(DatasetInfo):
                 layer.to_webknossos(layer_name)
                 for layer_name, layer in self.layers.items()
             ],
-            self.scale.toVec3Df(),
+            self.scale.to_float(),
         )

--- a/wkconnect/backends/neuroglancer/models.py
+++ b/wkconnect/backends/neuroglancer/models.py
@@ -92,5 +92,5 @@ class Dataset(DatasetInfo):
                 layer.to_webknossos(layer_name)
                 for layer_name, layer in self.layers.items()
             ],
-            self.scale,
+            self.scale.toVec3Df(),
         )

--- a/wkconnect/utils/json.py
+++ b/wkconnect/utils/json.py
@@ -1,7 +1,7 @@
 from dataclasses import InitVar
 from typing import Any, Iterable, Optional, Tuple, Union, get_type_hints
 
-from .types import JSON, Vec3D
+from .types import JSON, Vec3D, Vec3Df
 
 
 def from_json(data: JSON, cls: Optional[type]) -> Any:
@@ -69,7 +69,7 @@ def yield_jsons(
 
 def to_json(obj: Any) -> JSON:
     cls = type(obj)
-    if issubclass(cls, Vec3D):
+    if issubclass(cls, (Vec3D, Vec3Df)):
         return tuple(obj)
     elif hasattr(cls, "__annotations__"):
         annotations = get_type_hints(cls)

--- a/wkconnect/utils/types.py
+++ b/wkconnect/utils/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from operator import add, floordiv, mod, mul, sub
+from operator import add, floordiv, mod, mul, sub, truediv
 from typing import Any, Callable, Iterator, NamedTuple, Union
 
 import numpy as np
@@ -40,6 +40,9 @@ class Vec3D(NamedTuple):
     def pairmin(self, other: Any) -> Vec3D:
         return self._element_wise(other, min)
 
+    def toVec3Df(self) -> Vec3Df:
+        return Vec3Df(*map(float, self))
+
     @classmethod
     def zeros(cls) -> Vec3D:
         return cls(0, 0, 0)
@@ -47,6 +50,32 @@ class Vec3D(NamedTuple):
     @classmethod
     def ones(cls) -> Vec3D:
         return cls(1, 1, 1)
+
+
+class Vec3Df(NamedTuple):
+    x: float
+    y: float
+    z: float
+
+    def _element_wise(self, other: Any, fn: Callable[[float, Any], float]) -> Vec3Df:
+        if isinstance(other, tuple):
+            return Vec3Df(*(fn(a, b) for a, b in zip(self, other)))
+        return Vec3Df(*(fn(a, other) for a in self))  # pylint: disable=not-an-iterable
+
+    def __add__(self, other: Any) -> Vec3Df:
+        return self._element_wise(other, add)
+
+    def __sub__(self, other: Any) -> Vec3Df:
+        return self._element_wise(other, sub)
+
+    def __mul__(self, other: Any) -> Vec3Df:
+        return self._element_wise(other, mul)
+
+    def __truediv__(self, other: Any) -> Vec3Df:
+        return self._element_wise(other, truediv)
+
+    def toVec3D(self) -> Vec3D:
+        return Vec3D(*map(int, self))
 
 
 class Box3D(NamedTuple):

--- a/wkconnect/utils/types.py
+++ b/wkconnect/utils/types.py
@@ -40,7 +40,7 @@ class Vec3D(NamedTuple):
     def pairmin(self, other: Any) -> Vec3D:
         return self._element_wise(other, min)
 
-    def toVec3Df(self) -> Vec3Df:
+    def to_float(self) -> Vec3Df:
         return Vec3Df(*map(float, self))
 
     @classmethod
@@ -74,7 +74,7 @@ class Vec3Df(NamedTuple):
     def __truediv__(self, other: Any) -> Vec3Df:
         return self._element_wise(other, truediv)
 
-    def toVec3D(self) -> Vec3D:
+    def to_int(self) -> Vec3D:
         return Vec3D(*map(int, self))
 
 

--- a/wkconnect/webknossos/models.py
+++ b/wkconnect/webknossos/models.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, List, NamedTuple, Optional, Tuple, cast
+from typing import Any, List, NamedTuple, Optional, cast
 
 import numpy as np
 
-from ..utils.types import JSON, Box3D, Vec3D
+from ..utils.types import JSON, Box3D, Vec3D, Vec3Df
 
 
 class DataStoreStatus(NamedTuple):
@@ -65,7 +65,7 @@ class DataLayer:
 class DataSource(NamedTuple):
     id: DataSourceId
     dataLayers: List[DataLayer]
-    scale: Tuple[float, float, float]
+    scale: Vec3Df
 
 
 class UnusableDataSource(NamedTuple):


### PR DESCRIPTION
Currently wk-connect assumes that all resolutions are integers, which is not always the case for Boss datasets. This PR adds a `Vec3Df` datatype and uses it for the global scale and the Boss resolution normalization. I tested this locally.

Possible dataset to test this (min resolution 3.8, 3.8, 50.0):
```
{
    "boss": {
        "Connectomics_Department": {
            "acardona_0111_8": {
                "domain": "https://api.boss.neurodata.io",
                "collection": "cardona",
                "experiment": "acardona_0111_8__12_03_2017",
                "username": "…",
                "password": "…"
            }
        }
    }
}
```