### PR TITLE
fix thumbnail scale & allow boss datasets that are not done with downscaling

### DIFF
--- a/wkconnect/backends/boss/backend.py
+++ b/wkconnect/backends/boss/backend.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Dict, Optional, Tuple, cast
 
 import blosc
@@ -13,6 +14,8 @@ from ..backend import Backend, DatasetInfo
 from .client import Client
 from .models import Channel, Dataset, Experiment
 from .token_repository import TokenKey, TokenRepository
+
+logger = logging.getLogger()
 
 
 class Boss(Backend):
@@ -33,7 +36,10 @@ class Boss(Backend):
             domain, collection, experiment, channel, token_key
         )
         assert channel_info["base_resolution"] == 0
-        assert channel_info["downsample_status"] == "DOWNSAMPLED"
+        if channel_info["downsample_status"] != "DOWNSAMPLED":
+            logger.warn(
+                f"BOSS did not finish downsampling for \"{'/'.join([domain, collection, experiment])}\", current status is {channel_info['downsample_status']}."
+            )
 
         downsample_info = await self.client.get_downsample(
             domain, collection, experiment, channel, token_key

--- a/wkconnect/routes/datasets/thumbnail.py
+++ b/wkconnect/routes/datasets/thumbnail.py
@@ -27,7 +27,7 @@ async def get_thumbnail(
     )
     backend = request.app.backends[backend_name]
     layer = [i for i in dataset.to_webknossos().dataLayers if i.name == layer_name][0]
-    scale = 3
+    scale = min(3, len(layer.resolutions) - 1)
     center = layer.boundingBox.box().center()
     size = Vec3D(width, height, 1)
     data = (


### PR DESCRIPTION
This PR
* fixes the thumbnail generation for datasets with less than 4 resolutions, 
* allows BOSS datasets that are not yet finished with downscaling, logging a warning instead of having an assertion.

I tested this locally, code-review should be enough :-)