### PR TITLE
neuroglancer: accept any mimetype for info.json

### DIFF
--- a/wkconnect/backends/neuroglancer/backend.py
+++ b/wkconnect/backends/neuroglancer/backend.py
@@ -79,7 +79,7 @@ class Neuroglancer(Backend):
             async with await self.http_client.get(
                 info_url, headers=await get_header(token)
             ) as r:
-                response = await r.json()
+                response = await r.json(content_type=None)
         except ClientResponseError as e:
             if e.status == 403:
                 raise NeuroglancerAuthenticationMissingError(


### PR DESCRIPTION
Needed for this segmentation, which has mimetype `application/octet-stream`:
https://storage.googleapis.com/fafb-ffn1-20190521/segmentation/info

See https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.json