### PR TITLE
Update readme, rename default orga

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # webknossos-connect
-A [webKnossos](https://github.com/scalableminds/webknossos) compatible data connector written in Python. 
+A [webKnossos](https://github.com/scalableminds/webknossos) compatible data connector written in Python.
 
 webKnossos-connect serves as an adapter between the webKnossos data store interface and other alternative data storage servers (e.g BossDB) or static files hosted on Cloud Storage (e.g. Neuroglancer Precomputed)
 
@@ -17,8 +17,8 @@ Install webKnossos-connect using Docker or use the instructions for native insta
 ### 2. Connecting to webKnossos
 Register your webknossos-connect instance with your main webKnossos instance. Modify the webKnossos Postgres database:
   ```
-  INSERT INTO "webknossos"."datastores"("name","url","key","isscratch","isdeleted","isforeign","isconnector")
-  VALUES (E'connect', E'http://localhost:8000', E'secret-key', FALSE, FALSE, FALSE, TRUE);
+  INSERT INTO "webknossos"."datastores"("name","url","publicurl","key","isscratch","isdeleted","isforeign","isconnector")
+  VALUES (E'connect', E'http://localhost:8000', E'http://localhost:8000', E'secret-key', FALSE, FALSE, FALSE, TRUE);
   ```
 ### 3. Adding Datasets
 Add and configure datasets to webKnossos-connect to make them available for viewing in webKnossos
@@ -65,7 +65,7 @@ curl http:/<webKnossos-connect>/data/datasets -X POST -H "Content-Type: applicat
 ```
 
 #### 3.2 webKnossos UI
-Alternatively, new datasets can be added directly through the webKnossos UI. Configure and import a new datasets from the webKnossos dashboard. (Dashboard -> Datasets -> Upload Dataset -> Add wk-connect Dataset) 
+Alternatively, new datasets can be added directly through the webKnossos UI. Configure and import a new datasets from the webKnossos dashboard. (Dashboard -> Datasets -> Upload Dataset -> Add wk-connect Dataset)
 
 [Read more in the webKnossos docs.](https://docs.webknossos.org/guides/datasets#uploading-through-the-web-browser)
 
@@ -95,7 +95,7 @@ poetry install
 
 * Add webknossos-connect to the webKnossos database:
   ```
-  INSERT INTO "webknossos"."datastores"("name","url","key","isscratch","isdeleted","isforeign") 
+  INSERT INTO "webknossos"."datastores"("name","url","key","isscratch","isdeleted","isforeign")
   VALUES (E'connect',E'http://localhost:8000',E'k',FALSE,FALSE,FALSE);
   ```
 * `python -m wkconnect`

--- a/data/datasets.json
+++ b/data/datasets.json
@@ -1,7 +1,7 @@
 {
     "boss": {},
     "neuroglancer": {
-        "Connectomics_Department": {
+        "sample_organization": {
             "fafb_v14": {
                 "layers": {
                     "image": {


### PR DESCRIPTION
Adapting webknossos-connect to some recent changes in webknossos:

The `publicurl` has been added to the webknossos.datastores table.
Also, the default organization has been renamed to “sample_organization”.