### PR TITLE
Histogram route

### DIFF
--- a/wkconnect/routes/datasets/__init__.py
+++ b/wkconnect/routes/datasets/__init__.py
@@ -2,9 +2,15 @@ from sanic import Blueprint
 
 from .datasource_properties import datasource_properties
 from .read_data import read_data
+from .histogram import histogram
 from .thumbnail import thumbnail
 from .upload import upload
 
 datasets = Blueprint.group(
-    datasource_properties, read_data, thumbnail, upload, url_prefix="/datasets"
+    datasource_properties,
+    read_data,
+    thumbnail,
+    histogram,
+    upload,
+    url_prefix="/datasets",
 )

--- a/wkconnect/routes/datasets/__init__.py
+++ b/wkconnect/routes/datasets/__init__.py
@@ -1,8 +1,8 @@
 from sanic import Blueprint
 
 from .datasource_properties import datasource_properties
-from .read_data import read_data
 from .histogram import histogram
+from .read_data import read_data
 from .thumbnail import thumbnail
 from .upload import upload
 

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -1,6 +1,6 @@
 import asyncio
-from typing import List
 from collections import OrderedDict
+from typing import List
 
 import numpy as np
 from sanic import Blueprint, response
@@ -9,11 +9,9 @@ from sanic.request import Request
 from ...utils.json import to_json
 from ...utils.types import Vec3D
 from ...webknossos.access import AccessRequest, authorized
-from ...webknossos.models import (
-    DataRequest as WKDataRequest,
-    BoundingBox as WkBoundingBox,
-    Histogram,
-)
+from ...webknossos.models import BoundingBox as WkBoundingBox
+from ...webknossos.models import DataRequest as WKDataRequest
+from ...webknossos.models import Histogram
 
 histogram = Blueprint(__name__)
 
@@ -80,7 +78,7 @@ async def histogram_post(
 def generate_sample_positions(
     iterations: int, bounding_box: WkBoundingBox, resolution_limit: int
 ) -> List[Vec3D]:
-    positions = []
+    positions: List[Vec3D] = []
     for exponent in range(1, iterations + 1):
         power = 2 ** exponent
         distance = Vec3D(

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -1,32 +1,46 @@
 import asyncio
-import json
 from typing import List
+from collections import OrderedDict
 
 import numpy as np
 from sanic import Blueprint, response
 from sanic.request import Request
 
-from ...utils.json import from_json
+from ...utils.json import to_json
 from ...utils.types import Vec3D
 from ...webknossos.access import AccessRequest, authorized
-from ...webknossos.models import DataRequest as WKDataRequest
+from ...webknossos.models import (
+    DataRequest as WKDataRequest,
+    BoundingBox as WkBoundingBox,
+    Histogram,
+)
 
 histogram = Blueprint(__name__)
 
 
 @histogram.route(
-    "/<organization_name>/<dataset_name>/layers/<layer_name>/histogram", methods=["POST"]
+    "/<organization_name>/<dataset_name>/layers/<layer_name>/histogram", methods=["GET"]
 )
 @authorized(AccessRequest.read_dataset)
 async def histogram_post(
-        request: Request, organization_name: str, dataset_name: str, layer_name: str
+    request: Request, organization_name: str, dataset_name: str, layer_name: str
 ) -> response.HTTPResponse:
     (backend_name, dataset) = request.app.repository.get_dataset(
         organization_name, dataset_name
     )
     backend = request.app.backends[backend_name]
 
-    bucket_requests = from_json(request.json, List[WKDataRequest])
+    layer = [i for i in dataset.to_webknossos().dataLayers if i.name == layer_name][0]
+
+    import time
+
+    before = time.time()
+    sample_positions = generate_sample_positions(2, layer.boundingBox, 32)
+    sample_positions_distinct = list(OrderedDict.fromkeys(sample_positions))
+
+    bucket_requests = [
+        WKDataRequest(position, 1, 32, False) for position in sample_positions_distinct
+    ]
 
     buckets = await asyncio.gather(
         *(
@@ -40,18 +54,51 @@ async def histogram_post(
             for r in bucket_requests
         )
     )
-    missing_buckets = [index for index, data in enumerate(buckets) if data is None]
     existing_buckets = [
-        data
-        for r, data in zip(bucket_requests, buckets)
-        if data is not None
+        data for r, data in zip(bucket_requests, buckets) if data is not None
     ]
-    data = (
-        np.concatenate(existing_buckets) if len(existing_buckets) > 0 else b""
+    data = np.concatenate(existing_buckets) if len(existing_buckets) > 0 else b""
+    data = data[np.nonzero(data)]
+
+    after = time.time()
+    print(
+        f"fetched histogram data for {len(sample_positions_distinct)} positions, shape {data.shape} dtype {data.dtype}. took {(after - before)*1000:.2f} ms "
     )
 
-    headers = {
-        "Access-Control-Expose-Headers": "MISSING-BUCKETS",
-        "MISSING-BUCKETS": json.dumps(missing_buckets),
-    }
-    return response.raw(data, headers=headers)
+    if np.issubdtype(data.dtype, np.integer):
+        minimum, maximum = np.iinfo(data.dtype).min, np.iinfo(data.dtype).max
+        counts, _ = np.histogram(data, bins=np.arange(maximum))
+        histogram = Histogram(
+            [int(c) for c in list(counts)], len(data), int(minimum), int(maximum)
+        )
+    else:
+        raise Exception("float histograms not supported yet")
+
+    return response.json(to_json([histogram]))
+
+
+def generate_sample_positions(
+    iterations: int, bounding_box: WkBoundingBox, resolution_limit: int
+) -> List[Vec3D]:
+    positions = []
+    for exponent in range(1, iterations + 1):
+        power = 2 ** exponent
+        distance = Vec3D(
+            int(bounding_box.width / power),
+            int(bounding_box.height / power),
+            int(bounding_box.depth / power),
+        )
+        if (
+            distance.x < resolution_limit
+            and distance.y < resolution_limit
+            and distance.z < resolution_limit
+        ):
+            return positions
+        top_left = bounding_box.topLeft
+        positions_for_exponent = []
+        for x in range(1, power):
+            for y in range(1, power):
+                for z in range(1, power):
+                    positions_for_exponent.append(top_left + Vec3D(x, y, z) * distance)
+        positions.extend(positions_for_exponent)
+    return positions

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -1,0 +1,57 @@
+import asyncio
+import json
+from typing import List
+
+import numpy as np
+from sanic import Blueprint, response
+from sanic.request import Request
+
+from ...utils.json import from_json
+from ...utils.types import Vec3D
+from ...webknossos.access import AccessRequest, authorized
+from ...webknossos.models import DataRequest as WKDataRequest
+
+histogram = Blueprint(__name__)
+
+
+@histogram.route(
+    "/<organization_name>/<dataset_name>/layers/<layer_name>/histogram", methods=["POST"]
+)
+@authorized(AccessRequest.read_dataset)
+async def histogram_post(
+        request: Request, organization_name: str, dataset_name: str, layer_name: str
+) -> response.HTTPResponse:
+    (backend_name, dataset) = request.app.repository.get_dataset(
+        organization_name, dataset_name
+    )
+    backend = request.app.backends[backend_name]
+
+    bucket_requests = from_json(request.json, List[WKDataRequest])
+
+    buckets = await asyncio.gather(
+        *(
+            backend.read_data(
+                dataset,
+                layer_name,
+                r.zoomStep,
+                Vec3D(*r.position),
+                Vec3D(r.cubeSize, r.cubeSize, r.cubeSize),
+            )
+            for r in bucket_requests
+        )
+    )
+    missing_buckets = [index for index, data in enumerate(buckets) if data is None]
+    existing_buckets = [
+        data
+        for r, data in zip(bucket_requests, buckets)
+        if data is not None
+    ]
+    data = (
+        np.concatenate(existing_buckets) if len(existing_buckets) > 0 else b""
+    )
+
+    headers = {
+        "Access-Control-Expose-Headers": "MISSING-BUCKETS",
+        "MISSING-BUCKETS": json.dumps(missing_buckets),
+    }
+    return response.raw(data, headers=headers)

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -69,8 +69,16 @@ async def histogram_post(
         histogram = Histogram(
             [int(c) for c in list(counts)], len(data), int(minimum), int(maximum)
         )
+    elif np.issubdtype(data.dtype, np.float):
+        minimum, maximum = np.min(data), np.max(data)
+        bucket_size = (maximum - minimum) / 255
+        bucket_size = 1.0 if np.isclose(bucket_size, 0.0) else bucket_size
+        counts, _ = np.histogram(data, bins=np.arange(minimum, maximum, bucket_size))
+        histogram = Histogram(
+            [int(c) for c in list(counts)], len(data), float(minimum), float(maximum)
+        )
     else:
-        raise Exception("float histograms not supported yet")
+        raise Exception("Histogram for data type {data.dtype} is not supported.")
 
     return response.json(to_json([histogram]))
 

--- a/wkconnect/webknossos/models.py
+++ b/wkconnect/webknossos/models.py
@@ -39,6 +39,13 @@ class DataSourceId(NamedTuple):
     name: str
 
 
+class Histogram(NamedTuple):
+    elementCounts: List[int]
+    numberOfElements: int
+    min: float
+    max: float
+
+
 @dataclass(unsafe_hash=True)
 class DataLayer:
     name: str


### PR DESCRIPTION
Implement one of the missing routes (compare #22 ) which samples positions from the dataset to create an intensity histogram.
(Integral datatypes only, for now)
We still have to think about speed (took 22s for remotely hosted dataset)