### PR TITLE
Fix zoomstep wkw

### DIFF
--- a/wkconnect/backends/wkw/models.py
+++ b/wkconnect/backends/wkw/models.py
@@ -59,6 +59,8 @@ class Dataset(DatasetInfo):
         self, layer_name: str, zoom_step: int
     ) -> Tuple[DatasetHandle, Mag]:
         layer = self.dataset_handle.get_layer(layer_name)
+        # Finding the right mag for the zoom_step:
+        # 2 ** zoomStep = max(mag.x, mag.y, mag.z)
         mag = next(
             mag for mag in layer.mags.keys() if 2 ** zoom_step == max(mag.to_array())
         )

--- a/wkconnect/backends/wkw/models.py
+++ b/wkconnect/backends/wkw/models.py
@@ -62,16 +62,16 @@ class Dataset(DatasetInfo):
         # Finding the right mag for the zoom_step:
         # 2 ** zoomStep = max(mag.x, mag.y, mag.z)
         mag_datasets = [
-            mag
-            for mag in layer.mags.values()
-            if (2 ** zoom_step) == max(Mag(mag.name).to_array())
+            mag_dataset
+            for mag_dataset in layer.mags.values()
+            if (2 ** zoom_step) == Mag(mag_dataset.name).as_np().max()
         ]
         if len(mag_datasets) < 1:
             return None
         mag_dataset = mag_datasets[0]
 
         data_handle = self.wkw_cache.get_dataset(str(mag_dataset.view.path))
-        return (data_handle, mag_dataset.name)
+        return (data_handle, Mag(mag_dataset.name))
 
     @alru_cache(maxsize=2 ** 12, cache_exceptions=False)
     async def read_data(

--- a/wkconnect/backends/wkw/models.py
+++ b/wkconnect/backends/wkw/models.py
@@ -64,7 +64,7 @@ class Dataset(DatasetInfo):
         mag = next(
             mag
             for mag in layer.mags.keys()
-            if 2 ** zoom_step == max(Mag(mag.to_array()))
+            if 2 ** zoom_step == max(Mag(mag).to_array())
         )
         mag_dataset = layer.get_mag(mag)
         data_handle = self.wkw_cache.get_dataset(str(mag_dataset.view.path))

--- a/wkconnect/backends/wkw/models.py
+++ b/wkconnect/backends/wkw/models.py
@@ -59,8 +59,9 @@ class Dataset(DatasetInfo):
         self, layer_name: str, zoom_step: int
     ) -> Tuple[DatasetHandle, Mag]:
         layer = self.dataset_handle.get_layer(layer_name)
-        available_mags = {max(mag.to_array()): mag for mag in layer.mags.keys()}
-        mag = available_mags[2 ** zoom_step]
+        mag = next(
+            mag for mag in layer.mags.keys() if 2 ** zoom_step == max(mag.to_array())
+        )
         mag_dataset = layer.get_mag(mag)
         data_handle = self.wkw_cache.get_dataset(str(mag_dataset.view.path))
         return (data_handle, mag)

--- a/wkconnect/backends/wkw/models.py
+++ b/wkconnect/backends/wkw/models.py
@@ -62,7 +62,9 @@ class Dataset(DatasetInfo):
         # Finding the right mag for the zoom_step:
         # 2 ** zoomStep = max(mag.x, mag.y, mag.z)
         mag = next(
-            mag for mag in layer.mags.keys() if 2 ** zoom_step == max(mag.to_array())
+            mag
+            for mag in layer.mags.keys()
+            if 2 ** zoom_step == max(Mag(mag.to_array()))
         )
         mag_dataset = layer.get_mag(mag)
         data_handle = self.wkw_cache.get_dataset(str(mag_dataset.view.path))

--- a/wkconnect/backends/wkw/models.py
+++ b/wkconnect/backends/wkw/models.py
@@ -59,8 +59,8 @@ class Dataset(DatasetInfo):
         self, layer_name: str, zoom_step: int
     ) -> Tuple[DatasetHandle, Mag]:
         layer = self.dataset_handle.get_layer(layer_name)
-        available_mags = sorted([Mag(mag) for mag in layer.mags.keys()])
-        mag = available_mags[zoom_step]
+        available_mags = {max(mag.to_array()): mag for mag in layer.mags.keys()}
+        mag = available_mags[2 ** zoom_step]
         mag_dataset = layer.get_mag(mag)
         data_handle = self.wkw_cache.get_dataset(str(mag_dataset.view.path))
         return (data_handle, mag)

--- a/wkconnect/backends/wkw/models.py
+++ b/wkconnect/backends/wkw/models.py
@@ -57,18 +57,21 @@ class Dataset(DatasetInfo):
     @lru_cache(maxsize=1000)
     def get_data_handle(
         self, layer_name: str, zoom_step: int
-    ) -> Tuple[DatasetHandle, Mag]:
+    ) -> Optional[Tuple[DatasetHandle, Mag]]:
         layer = self.dataset_handle.get_layer(layer_name)
         # Finding the right mag for the zoom_step:
         # 2 ** zoomStep = max(mag.x, mag.y, mag.z)
-        mag = next(
+        mag_datasets = [
             mag
-            for mag in layer.mags.keys()
-            if 2 ** zoom_step == max(Mag(mag).to_array())
-        )
-        mag_dataset = layer.get_mag(mag)
+            for mag in layer.mags.values()
+            if (2 ** zoom_step) == max(Mag(mag.name).to_array())
+        ]
+        if len(mag_datasets) < 1:
+            return None
+        mag_dataset = mag_datasets[0]
+
         data_handle = self.wkw_cache.get_dataset(str(mag_dataset.view.path))
-        return (data_handle, mag)
+        return (data_handle, mag_dataset.name)
 
     @alru_cache(maxsize=2 ** 12, cache_exceptions=False)
     async def read_data(
@@ -78,7 +81,10 @@ class Dataset(DatasetInfo):
             32, 32, 32
         ), "Only buckets of 32 edge length are supported"
         assert shape % 32 == Vec3D(0, 0, 0), "Only 32-aligned buckets are supported"
-        data_handle, mag = self.get_data_handle(layer_name, zoom_step)
+        data_handle_opt = self.get_data_handle(layer_name, zoom_step)
+        if data_handle_opt is None:
+            return None
+        data_handle, mag = data_handle_opt
         offset = (
             np.array([wk_offset.x, wk_offset.y, wk_offset.z]) / mag.as_np()
         ).astype(np.uint32)

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -86,7 +86,10 @@ def align_positions_with_mag(
     # For the WKW backend, the bucket requests need to be bucket-aligned in the target mag
     available_mags = sorted([Mag(mag["resolution"]) for mag in layer.wkwResolutions])
     mag = available_mags[0]
+
+    # This is equivalent to `int(log2(mag.as_np().max()))`, but avoids intermediate floats
     zoom_step = mag.as_np().max().bit_length() - 1
+
     align = Vec3D(*(mag.as_np() * BUCKET_SIZE))
     sample_positions = [
         Vec3D(*((position // align) * align)) for position in sample_positions

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import List, Tuple
 
 import numpy as np
+import math
 from sanic import Blueprint, response
 from sanic.request import Request
 from wkcuber.mag import Mag
@@ -85,8 +86,8 @@ def align_positions_with_mag(
 ) -> Tuple[List[Vec3D], int]:
     # For the WKW backend, the bucket requests need to be bucket-aligned in the target mag
     available_mags = sorted([Mag(mag["resolution"]) for mag in layer.wkwResolutions])
-    zoom_step = min(1, len(available_mags) - 1)
-    mag = available_mags[zoom_step]
+    mag = available_mags[0]
+    zoom_step = math.log2(mag.as_np().max())
     align = Vec3D(*(mag.as_np() * BUCKET_SIZE))
     sample_positions = [
         Vec3D(*((position // align) * align)) for position in sample_positions

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -1,8 +1,8 @@
 import asyncio
+import math
 from typing import List, Tuple
 
 import numpy as np
-import math
 from sanic import Blueprint, response
 from sanic.request import Request
 from wkcuber.mag import Mag

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -87,7 +87,7 @@ def align_positions_with_mag(
     # For the WKW backend, the bucket requests need to be bucket-aligned in the target mag
     available_mags = sorted([Mag(mag["resolution"]) for mag in layer.wkwResolutions])
     mag = available_mags[0]
-    zoom_step = math.log2(mag.as_np().max())
+    zoom_step = int(math.log2(mag.as_np().max()))
     align = Vec3D(*(mag.as_np() * BUCKET_SIZE))
     sample_positions = [
         Vec3D(*((position // align) * align)) for position in sample_positions

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -88,7 +88,7 @@ def align_positions_with_mag(
     mag = available_mags[0]
 
     # This is equivalent to `int(log2(mag.as_np().max()))`, but avoids intermediate floats
-    zoom_step = mag.as_np().max().bit_length() - 1
+    zoom_step = int(mag.as_np().max()).bit_length() - 1
 
     align = Vec3D(*(mag.as_np() * BUCKET_SIZE))
     sample_positions = [

--- a/wkconnect/routes/datasets/histogram.py
+++ b/wkconnect/routes/datasets/histogram.py
@@ -1,5 +1,4 @@
 import asyncio
-import math
 from typing import List, Tuple
 
 import numpy as np
@@ -87,7 +86,7 @@ def align_positions_with_mag(
     # For the WKW backend, the bucket requests need to be bucket-aligned in the target mag
     available_mags = sorted([Mag(mag["resolution"]) for mag in layer.wkwResolutions])
     mag = available_mags[0]
-    zoom_step = int(math.log2(mag.as_np().max()))
+    zoom_step = mag.as_np().max().bit_length() - 1
     align = Vec3D(*(mag.as_np() * BUCKET_SIZE))
     sample_positions = [
         Vec3D(*((position // align) * align)) for position in sample_positions


### PR DESCRIPTION
Fixes the zoomStep handling in the wkw backend. Previously, it would use the zoomStep as an index for the available mags. That works iff there are mags in ordinary order, i.e. 1, 2, 4, ... . This PR implements it properly: `2**zoomStep = max(mag.x, mag.y, mag.z)`