### PR TITLE
Show neuroglancer meshes in webKnossos

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -327,6 +327,17 @@ pyjwt = ">=1.5.3,<3.0.0"
 six = ">=1.11.0,<2.0.0"
 
 [[package]]
+name = "h5py"
+version = "3.6.0"
+description = "Read and write HDF5 files from Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = ">=1.14.5"
+
+[[package]]
 name = "httptools"
 version = "0.2.0"
 description = "A collection of framework independent HTTP protocol utils."
@@ -1047,7 +1058,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "15b1943172fee2204845bd816dc188e2165f6b82429c2d1e5a0ad130692efd62"
+content-hash = "a4accc60b1744865bd9ca043a4130ed675c0829dfc1f8ecd7de253604bdff259"
 
 [metadata.files]
 aiofiles = [
@@ -1366,6 +1377,24 @@ future = [
 gcloud-aio-auth = [
     {file = "gcloud-aio-auth-3.6.0.tar.gz", hash = "sha256:0085a8b6539c9cf6fab514349b9e20e9628299e1766adc8dccd14ccb142bba28"},
     {file = "gcloud_aio_auth-3.6.0-py2.py3-none-any.whl", hash = "sha256:623ca19a8d1b3493bd31ea660d242c8c43f541f170a7ebc710869392cbeada2a"},
+]
+h5py = [
+    {file = "h5py-3.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a5320837c60870911645e9a935099bdb2be6a786fcf0dac5c860f3b679e2de55"},
+    {file = "h5py-3.6.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98646e659bf8591a2177e12a4461dced2cad72da0ba4247643fd118db88880d2"},
+    {file = "h5py-3.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:5996ff5adefd2d68c330a4265b6ef92e51b2fc674834a5990add5033bf109e20"},
+    {file = "h5py-3.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c9a5529343a619fea777b7caa27d493595b28b5af8b005e8d1817559fcccf493"},
+    {file = "h5py-3.6.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e2b49c48df05e19bb20b400b7ff7dc6f1ee36b84dc717c3771c468b33697b466"},
+    {file = "h5py-3.6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd9447633b0bafaf82190d9a8d56f3cb2e8d30169483aee67d800816e028190a"},
+    {file = "h5py-3.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1c5acc660c458421e88c4c5fe092ce15923adfac4c732af1ac4fced683a5ea97"},
+    {file = "h5py-3.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:35ab552c6f0a93365b3cb5664a5305f3920daa0a43deb5b2c547c52815ec46b9"},
+    {file = "h5py-3.6.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:542781d50e1182b8fb619b1265dfe1c765e18215f818b0ab28b2983c28471325"},
+    {file = "h5py-3.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f39242960b8d7f86f3056cc2546aa3047ff4835985f6483229af8f029e9c8db"},
+    {file = "h5py-3.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ecedf16c613973622a334701f67edcc0249469f9daa0576e994fb20ac0405db"},
+    {file = "h5py-3.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d8cacad89aa7daf3626fce106f7f2662ac35b14849df22d252d0d8fab9dc1c0b"},
+    {file = "h5py-3.6.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dbaa1ed9768bf9ff04af0919acc55746e62b28333644f0251f38768313f31745"},
+    {file = "h5py-3.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:954c5c39a09b5302f69f752c3bbf165d368a65c8d200f7d5655e0fa6368a75e6"},
+    {file = "h5py-3.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:9fd8a14236fdd092a20c0bdf25c3aba3777718d266fabb0fdded4fcf252d1630"},
+    {file = "h5py-3.6.0.tar.gz", hash = "sha256:8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29"},
 ]
 httptools = [
     {file = "httptools-0.2.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:79dbc21f3612a78b28384e989b21872e2e3cf3968532601544696e4ed0007ce5"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -267,6 +267,17 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 
 [[package]]
+name = "dracopy"
+version = "0.0.19"
+description = "Python wrapper for Google's Draco Mesh Compression Library"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = "*"
+
+[[package]]
 name = "flake8"
 version = "3.9.2"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -543,6 +554,18 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "numpy-stl"
+version = "2.16.3"
+description = "Library to make reading, writing and modifying both binary and ascii STL files easy."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+numpy = "*"
+python-utils = ">=1.6.2"
+
+[[package]]
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
@@ -702,6 +725,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-utils"
+version = "2.5.6"
+description = "Python Utils is a module with some convenient utilities not included with the standard Python install"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 name = "pywavelets"
@@ -1013,7 +1047,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "927025c28ed21e88c0d9d5113321029ffbb2377acc260eaae405ee037ca76e26"
+content-hash = "15b1943172fee2204845bd816dc188e2165f6b82429c2d1e5a0ad130692efd62"
 
 [metadata.files]
 aiofiles = [
@@ -1135,6 +1169,14 @@ brotlipy = [
     {file = "brotlipy-0.7.0-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:79aaf217072840f3e9a3b641cccc51f7fc23037496bd71e26211856b93f4b4cb"},
     {file = "brotlipy-0.7.0-cp34-cp34m-win32.whl", hash = "sha256:a07647886e24e2fb2d68ca8bf3ada398eb56fd8eac46c733d4d95c64d17f743b"},
     {file = "brotlipy-0.7.0-cp34-cp34m-win_amd64.whl", hash = "sha256:c6cc0036b1304dd0073eec416cb2f6b9e37ac8296afd9e481cac3b1f07f9db25"},
+    {file = "brotlipy-0.7.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:382971a641125323e90486244d6266ffb0e1f4dd920fbdcf508d2a19acc7c3b3"},
+    {file = "brotlipy-0.7.0-cp35-abi3-manylinux1_i686.whl", hash = "sha256:82f61506d001e626ec3a1ac8a69df11eb3555a4878599befcb672c8178befac8"},
+    {file = "brotlipy-0.7.0-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:7ff18e42f51ebc9d9d77a0db33f99ad95f01dd431e4491f0eca519b90e9415a9"},
+    {file = "brotlipy-0.7.0-cp35-abi3-manylinux2010_i686.whl", hash = "sha256:8ef230ca9e168ce2b7dc173a48a0cc3d78bcdf0bd0ea7743472a317041a4768e"},
+    {file = "brotlipy-0.7.0-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:b7cf5bb69e767a59acc3da0d199d4b5d0c9fed7bef3ffa3efa80c6f39095686b"},
+    {file = "brotlipy-0.7.0-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:e5c549ae5928dda952463196180445c24d6fad2d73cb13bd118293aced31b771"},
+    {file = "brotlipy-0.7.0-cp35-abi3-win32.whl", hash = "sha256:79ab3bca8dd12c17e092273484f2ac48b906de2b4828dcdf6a7d520f99646ab3"},
+    {file = "brotlipy-0.7.0-cp35-abi3-win_amd64.whl", hash = "sha256:ac1d66c9774ee62e762750e399a0c95e93b180e96179b645f28b162b55ae8adc"},
     {file = "brotlipy-0.7.0-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:07194f4768eb62a4f4ea76b6d0df6ade185e24ebd85877c351daa0a069f1111a"},
     {file = "brotlipy-0.7.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7e31f7adcc5851ca06134705fcf3478210da45d35ad75ec181e1ce9ce345bb38"},
     {file = "brotlipy-0.7.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9448227b0df082e574c45c983fa5cd4bda7bfb11ea6b59def0940c1647be0c3c"},
@@ -1146,6 +1188,7 @@ brotlipy = [
     {file = "brotlipy-0.7.0-cp36-cp36m-win32.whl", hash = "sha256:2e5c64522364a9ebcdf47c5744a5ddeb3f934742d31e61ebfbbc095460b47162"},
     {file = "brotlipy-0.7.0-cp36-cp36m-win_amd64.whl", hash = "sha256:09ec3e125d16749b31c74f021aba809541b3564e5359f8c265cbae442810b41a"},
     {file = "brotlipy-0.7.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:4e4638b49835d567d447a2cfacec109f9a777f219f071312268b351b6839436d"},
+    {file = "brotlipy-0.7.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:5664fe14f3a613431db622172bad923096a303d3adce55536f4409c8e2eafba4"},
     {file = "brotlipy-0.7.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1379347337dc3d20b2d61456d44ccce13e0625db2611c368023b4194d5e2477f"},
     {file = "brotlipy-0.7.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:22a53ccebcce2425e19f99682c12be510bf27bd75c9b77a1720db63047a77554"},
     {file = "brotlipy-0.7.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4bac11c1ffba9eaa2894ec958a44e7f17778b3303c2ee9f99c39fcc511c26668"},
@@ -1268,8 +1311,10 @@ cryptography = [
     {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 cycler = [
@@ -1283,6 +1328,29 @@ czifile = [
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
     {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+]
+dracopy = [
+    {file = "DracoPy-0.0.19-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:aded2b5d7336658f3edf520f8f0fd394df52c59856e2391166410d9335770599"},
+    {file = "DracoPy-0.0.19-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:c7e63b529004cabeb6e4879da3a743e1b1fdd565f93fa9cd5ede3eff28464372"},
+    {file = "DracoPy-0.0.19-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1cc43fe946c696f46dcce8038e451969c64848cf1132770575a0d0e44c19e8ec"},
+    {file = "DracoPy-0.0.19-cp36-cp36m-win32.whl", hash = "sha256:a5a535c6e0d4b0fc66d55f53a57fbb01a2dd38fdf1f11fc4c535793a6ea39f8d"},
+    {file = "DracoPy-0.0.19-cp36-cp36m-win_amd64.whl", hash = "sha256:f0913945259494c87d3ceac5aaad463eb07a4c9a49c291fafec140faea6cb0ce"},
+    {file = "DracoPy-0.0.19-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:248e95779a15a5f9f1fdc19ef00cd478dddf016317b1c225a25e2982b21a837b"},
+    {file = "DracoPy-0.0.19-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:783f18e7109f7416179e7a4c664dc4b55cf1a8d8d0221135229376157069a284"},
+    {file = "DracoPy-0.0.19-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:679f153285da7ac1c6d7d3bae89093fa53ff356e7e06782de83dd537e8b72ff8"},
+    {file = "DracoPy-0.0.19-cp37-cp37m-win32.whl", hash = "sha256:292ba82a2eb5a81ad65ef87a27b9375e494aa159c23bc190ea2b8592d1fc53c7"},
+    {file = "DracoPy-0.0.19-cp37-cp37m-win_amd64.whl", hash = "sha256:365887568b2afa1fa7efaa61dac79c8dbe9e6d09b6a61b5a72de290da2b6cd78"},
+    {file = "DracoPy-0.0.19-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:b7fec865649bfa2801496cae2c7c0a8c38ad64ab7e396d0ddbf42d4a8b4970af"},
+    {file = "DracoPy-0.0.19-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:c2e2c766fe6a221042a5aa50832007de437ab6fa0400aec70ea97195af76f91e"},
+    {file = "DracoPy-0.0.19-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:44476b27512ebe997f61b1926dacaf25ac5627ec310f7a6a568e79a35c55601b"},
+    {file = "DracoPy-0.0.19-cp38-cp38-win32.whl", hash = "sha256:87121990973ee6ac0063aac1ad5201affea2304c1b1b7ad8aa65427ddfacc72d"},
+    {file = "DracoPy-0.0.19-cp38-cp38-win_amd64.whl", hash = "sha256:934ae24c866be78f3e4b0e0370cbcf728e9d211a527314cce7ca6ef65479f217"},
+    {file = "DracoPy-0.0.19-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b12e94cae0d19c833825152d097d7aff45d267c33ebd6a966f0ec0df8b33ac9b"},
+    {file = "DracoPy-0.0.19-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b367e709f2e0c3abb8ddf3c398f70f32af7a465a4f3d05a6a872f96ea3fbaddd"},
+    {file = "DracoPy-0.0.19-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:9725a5dde8426d923490cb578f68691a885aaba32df00c536667a308c14b4a45"},
+    {file = "DracoPy-0.0.19-cp39-cp39-win32.whl", hash = "sha256:5e802362965a48e49f06ec4e76e1d0601711a2e3e9ae89151b1393372cbf022c"},
+    {file = "DracoPy-0.0.19-cp39-cp39-win_amd64.whl", hash = "sha256:db4039e9ceb8616bc5b416cf666ad14e2367552289dc37977a6daad706e5b89c"},
+    {file = "DracoPy-0.0.19.tar.gz", hash = "sha256:393db702c670fd964913673f76399e09ff3ff3e473d102a26c0eb4b9e23adf5e"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -1379,14 +1447,18 @@ kiwisolver = [
     {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31"},
     {file = "kiwisolver-1.3.1-cp37-cp37m-win32.whl", hash = "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc"},
     {file = "kiwisolver-1.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:24cc411232d14c8abafbd0dddb83e1a4f54d77770b53db72edcfe1d611b3bf11"},
     {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ef6eefcf3944e75508cdfa513c06cf80bafd7d179e14c1334ebdca9ebb8c2c66"},
     {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3"},
     {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131"},
     {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de"},
     {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18"},
     {file = "kiwisolver-1.3.1-cp38-cp38-win32.whl", hash = "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81"},
     {file = "kiwisolver-1.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6d9d8d9b31aa8c2d80a690693aebd8b5e2b7a45ab065bb78f1609995d2c79240"},
     {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:792e69140828babe9649de583e1a03a0f2ff39918a71782c76b3c683a67c6dfd"},
     {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598"},
     {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882"},
     {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621"},
@@ -1396,6 +1468,7 @@ kiwisolver = [
     {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d"},
     {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3"},
     {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6"},
+    {file = "kiwisolver-1.3.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d6563ccd46b645e966b400bb8a95d3457ca6cf3bba1e908f9e0927901dfebeb1"},
     {file = "kiwisolver-1.3.1.tar.gz", hash = "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248"},
 ]
 lazy-object-proxy = [
@@ -1545,6 +1618,10 @@ numpy = [
     {file = "numpy-1.20.3-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e465afc3b96dbc80cf4a5273e5e2b1e3451286361b4af70ce1adb2984d392f9"},
     {file = "numpy-1.20.3.zip", hash = "sha256:e55185e51b18d788e49fe8305fd73ef4470596b33fc2c1ceb304566b99c71a69"},
 ]
+numpy-stl = [
+    {file = "numpy-stl-2.16.3.tar.gz", hash = "sha256:95890627001efb2cb8d17418730cdc1bdd64b8dbb9862b01a8e0359d79fe863e"},
+    {file = "numpy_stl-2.16.3-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:bd6c0fb893b7d3ea5a90d39de8f3c776e41462df45e179c3661e97b05fb8e536"},
+]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
@@ -1662,6 +1739,10 @@ pytest = [
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+python-utils = [
+    {file = "python-utils-2.5.6.tar.gz", hash = "sha256:352d5b1febeebf9b3cdb9f3c87a3b26ef22d3c9e274a8ec1e7048ecd2fac4349"},
+    {file = "python_utils-2.5.6-py2.py3-none-any.whl", hash = "sha256:18fbc1a1df9a9061e3059a48ebe5c8a66b654d688b0e3ecca8b339a7f168f208"},
 ]
 pywavelets = [
     {file = "PyWavelets-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:35959c041ec014648575085a97b498eafbbaa824f86f6e4a59bfdef8a3fe6308"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ sanic = "21.3.4"
 sanic_cors = "^1.0.0"
 tifffile = "^2020.9.3"
 wkcuber = "^0.5"
+DracoPy = "^0.0.19"
+numpy-stl = "^2.16.3"
 
 [tool.poetry.dev-dependencies]
 autoflake = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ tifffile = "^2020.9.3"
 wkcuber = "^0.5"
 DracoPy = "^0.0.19"
 numpy-stl = "^2.16.3"
+h5py = "^3.6.0"
 
 [tool.poetry.dev-dependencies]
 autoflake = "*"

--- a/wkconnect/backends/backend.py
+++ b/wkconnect/backends/backend.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import numpy as np
 from aiohttp import ClientSession
@@ -51,6 +51,52 @@ class Backend(metaclass=ABCMeta):
         :param shape: in scale voxels
         :returns: numpy array of shape shape
         """
+
+    async def get_meshes(
+        self, dataset: DatasetInfo, layer_name: str
+    ) -> Optional[List[str]]:
+        """
+        List the available meshfiles of a layer from the backend.
+
+        :param dataset:
+        :param layer_name:
+        :returns: list of meshfile names
+        """
+        raise NotImplementedError()
+
+    async def get_chunks_for_mesh(
+        self, dataset: DatasetInfo, layer_name: str, mesh_name: str, segment_id: int
+    ) -> Optional[List[Vec3D]]:
+        """
+        List the available chunks of a mesh from the backend.
+
+        :param dataset:
+        :param layer_name:
+        :param mesh_name:
+        :param segment_id:
+        :returns: list of tuples with the top-left position of each chunk
+        """
+        raise NotImplementedError()
+
+    async def get_chunk_data_for_mesh(
+        self,
+        dataset: DatasetInfo,
+        layer_name: str,
+        mesh_name: str,
+        segment_id: int,
+        position: Vec3D,
+    ) -> Optional[bytes]:
+        """
+        Read a chunk of a mesh from the backend.
+
+        :param dataset:
+        :param layer_name:
+        :param mesh_name:
+        :param segment_id:
+        :param position:
+        :returns: bytes of a mesh chunk in binary STL format
+        """
+        raise NotImplementedError()
 
     @abstractmethod
     def clear_dataset_cache(self, dataset: DatasetInfo) -> None:

--- a/wkconnect/backends/neuroglancer/backend.py
+++ b/wkconnect/backends/neuroglancer/backend.py
@@ -11,11 +11,10 @@ from aiohttp import ClientResponseError, ClientSession
 from async_lru import alru_cache
 from gcloud.aio.auth import Token
 
-from wkconnect.backends.neuroglancer.meshes import Meshfile, MeshfileLod, MeshInfo
-
 from ...utils.exceptions import RuntimeErrorWithUserMessage
 from ...utils.types import JSON, Box3D, Vec3D, Vec3Df
 from ..backend import Backend, DatasetInfo
+from ..neuroglancer.meshes import Meshfile, MeshfileLod, MeshInfo
 from .models import Dataset, Layer, Scale
 from .sharding import MinishardInfo, ShardingInfo
 
@@ -390,7 +389,6 @@ class Neuroglancer(Backend):
         chunk_id = np.uint64(segment_id)
         minishard_info = sharding_info.get_minishard_info(chunk_id)
         shard_url = f"{layer.source}/mesh/{sharding_info.format_shard_for_url(minishard_info)}.shard"
-        # print("shard_url", shard_url)
         minishard_index = await self.__read_minishard_index(
             shard_url, sharding_info, minishard_info, token
         )

--- a/wkconnect/backends/neuroglancer/meshes.py
+++ b/wkconnect/backends/neuroglancer/meshes.py
@@ -62,6 +62,11 @@ class Meshfile:
 
 @dataclass(frozen=True)
 class MeshInfo:
+    """
+    Stores the representation of the meshes of a segmentation layer.
+    The format is defined at https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/meshes.md.
+    """
+
     sharding: ShardingInfo
     _transform: Tuple[float, ...]
     vertex_quantization_bits: int

--- a/wkconnect/backends/neuroglancer/meshes.py
+++ b/wkconnect/backends/neuroglancer/meshes.py
@@ -1,0 +1,259 @@
+import asyncio
+from aiohttp import ClientSession
+from dataclasses import dataclass, replace
+import numpy as np
+from async_lru import alru_cache
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, cast
+
+
+from .sharding import MinishardInfo, ShardingInfo
+from ...utils.types import Vec3D, Vec3Df
+from wkconnect.backends.neuroglancer import sharding
+
+
+@dataclass(frozen=True)
+class MeshfileFragment:
+    position: Vec3Df
+    byte_offset: int
+    byte_size: int
+
+
+@dataclass(frozen=True)
+class MeshfileLod:
+    scale: int
+    vertex_offset: Vec3Df
+    chunk_shape: Vec3Df
+    fragments: List[MeshfileFragment]
+
+
+@dataclass(frozen=True)
+class Meshfile:
+    chunk_shape: Vec3Df
+    grid_origin: Vec3Df
+    lods: List[MeshfileLod]
+
+    def fragment_offset_and_shape(self, lod: int, fragment: int):
+        return (
+            self.grid_origin
+            + self.lods[lod].fragments[fragment].position
+            * self.chunk_shape
+            * self.lods[lod].scale,
+            self.grid_origin
+            + self.lods[lod].fragments[fragment].position
+            * self.chunk_shape
+            * self.lods[lod].scale
+            + self.chunk_shape * self.lods[lod].scale,
+            self.chunk_shape * self.lods[lod].scale,
+        )
+
+
+@dataclass(frozen=True)
+class MeshInfo:
+    sharding: ShardingInfo
+    transform: np.ndarray
+    vertex_quantization_bits: int
+    lod_scale_multiplier: int = 1
+
+    def parse_meshfile(self, buf: bytes, byte_offset: int):
+        p = 0
+        chunk_shape = np.frombuffer(buf[p : p + 12], dtype="f4").copy()
+        p += 12
+        grid_origin = np.frombuffer(buf[p : p + 12], dtype="f4").copy()
+        p += 12
+        num_lods = int(np.frombuffer(buf[p : p + 4], dtype="<u4").copy())
+        p += 4
+        lod_scales = np.frombuffer(buf[p : (p + num_lods * 4)], dtype="f4").copy()
+        p += num_lods * 4
+        vertex_offsets = (
+            np.frombuffer(buf[p : (p + num_lods * 3 * 4)], dtype="f4")
+            .reshape((-1, 3))
+            .copy()
+        )
+        p += num_lods * 3 * 4
+        num_fragments_per_lod = np.frombuffer(
+            buf[p : (p + num_lods * 4)], dtype="<u4"
+        ).copy()
+        p += num_lods * 4
+        lods = []
+        frag_byte_offset = 0
+        for lod in range(num_lods):
+            if num_fragments_per_lod[lod] > 0:
+                fragment_positions = (
+                    np.frombuffer(
+                        buf[p : (p + int(num_fragments_per_lod[lod]) * 3 * 4)],
+                        dtype="<u4",
+                    )
+                    .reshape((3, -1))
+                    .T.copy()
+                )
+                p += int(num_fragments_per_lod[lod]) * 3 * 4
+                fragment_byte_sizes = np.frombuffer(
+                    buf[p : (p + int(num_fragments_per_lod[lod]) * 4)], dtype="<u4"
+                ).copy()
+                fragment_byte_offsets = np.zeros(
+                    (num_fragments_per_lod[lod],), dtype="<u4"
+                )
+                fragment_byte_offsets[0] = frag_byte_offset
+                fragment_byte_offsets[1:] = frag_byte_offset + np.cumsum(
+                    fragment_byte_sizes[:-1]
+                )
+                frag_byte_offset += np.sum(fragment_byte_sizes)
+                p += int(num_fragments_per_lod[lod]) * 4
+
+                fragments = []
+                for i in range(num_fragments_per_lod[lod]):
+                    position = fragment_positions[i]
+                    global_position = (
+                        grid_origin
+                        + fragment_positions[i] * chunk_shape * lod_scales[lod]
+                    )
+                    fragments.append(
+                        MeshfileFragment(
+                            position=Vec3Df(
+                                *np.matmul(global_position, self.transform)[0:3]
+                            ),
+                            byte_offset=fragment_byte_offsets[i],
+                            byte_size=int(fragment_byte_sizes[i]),
+                        )
+                    )
+
+                lods.append(
+                    MeshfileLod(
+                        scale=int(lod_scales[lod]),
+                        vertex_offset=Vec3Df(*vertex_offsets[lod]),
+                        chunk_shape=Vec3Df(*chunk_shape * lod_scales[lod]),
+                        fragments=fragments,
+                    )
+                )
+
+        return Meshfile(
+            chunk_shape=Vec3Df(*chunk_shape),
+            grid_origin=Vec3Df(*grid_origin),
+            lods=[
+                replace(
+                    lod,
+                    fragments=[
+                        replace(
+                            frag,
+                            byte_offset=int(
+                                byte_offset - frag_byte_offset + frag.byte_offset
+                            ),
+                        )
+                        for frag in lod.fragments
+                    ],
+                )
+                for lod in lods
+            ],
+        )
+
+
+async def __read_ranged_data(
+    http_client: ClientSession, url: str, range: Tuple[int, int]
+) -> bytes:
+    if range[0] == range[1]:
+        return b""
+    headers = {"Range": f"bytes={int(range[0])}-{int(range[1]-1)}"}
+    async with await http_client.get(url, headers=headers) as r:
+        r.raise_for_status()
+        response_buffer = await r.read()
+    return response_buffer
+
+
+@alru_cache(maxsize=2 ** 12, cache_exceptions=False)
+async def __read_shard_index(
+    http_client: ClientSession, shard_url: str, sharding_info: ShardingInfo
+) -> np.ndarray:
+    shard_index_range = sharding_info.get_shard_index_range()
+    print("shard_index_range", shard_index_range)
+    index = sharding_info.parse_shard_index(
+        await __read_ranged_data(http_client, shard_url, shard_index_range)
+    )
+    return index
+
+
+@alru_cache(maxsize=2 ** 12, cache_exceptions=False)
+async def __read_minishard_index(
+    http_client: ClientSession,
+    shard_url: str,
+    sharding_info: ShardingInfo,
+    minishard_info: MinishardInfo,
+) -> np.ndarray:
+    shard_index = await __read_shard_index(http_client, shard_url, sharding_info)
+    minishard_index_range = sharding_info.get_minishard_index_range(
+        minishard_info.minishard_number, shard_index
+    )
+    print("minishare_index_range", minishard_index_range)
+    buf = await __read_ranged_data(http_client, shard_url, minishard_index_range)
+    index = sharding_info.parse_minishard_index(buf)
+    return index
+
+
+async def __read_sharded_mesh(
+    http_client: ClientSession, source_url: str, mesh_info: MeshInfo, segment_id: int
+) -> Optional[Meshfile]:
+    sharding_info = mesh_info.sharding
+    chunk_id = np.uint64(segment_id)
+    minishard_info = sharding_info.get_minishard_info(chunk_id)
+    shard_url = f"{source_url}%2F{sharding_info.format_shard_for_url(minishard_info)}.shard?alt=media"
+    print("shard_url", shard_url)
+    minishard_index = await __read_minishard_index(
+        http_client, shard_url, sharding_info, minishard_info
+    )
+    chunk_range = sharding_info.get_chunk_range(chunk_id, minishard_index)
+    print("chunk_range", chunk_range)
+    if chunk_range is None:
+        return None
+    buf = sharding_info.parse_chunk(
+        await __read_ranged_data(http_client, shard_url, chunk_range)
+    )
+
+    return mesh_info.parse_meshfile(buf, chunk_range[0])
+
+
+async def main():
+    async with ClientSession(raise_for_status=True) as http_client:
+        # segment_id = 673639143
+        segment_id = 977667682
+
+        info = MeshInfo(
+            sharding=ShardingInfo(
+                dataset_size=Vec3D(0, 0, 0),
+                chunk_size=Vec3D(0, 0, 0),
+                preshift_bits=6,
+                minishard_bits=8,
+                minishard_index_encoding="gzip",
+                shard_bits=10,
+                data_encoding="gzip",
+                hashfn="murmurhash3_x86_128",
+            ),
+            lod_scale_multiplier=1,
+            transform=np.array([[16, 0, 0, 0], [0, 16, 0, 0], [0, 0, 16, 0]]),
+            vertex_quantization_bits=16,
+        )
+
+        mesh = await __read_sharded_mesh(
+            http_client,
+            "https://www.googleapis.com/storage/v1/b/neuroglancer-janelia-flyem-hemibrain/o/v1.0%2Fsegmentation%2Fmesh",
+            info,
+            segment_id,
+        )
+
+        print(mesh)
+        for i, lod in enumerate(mesh.lods):
+            print(
+                "Mean frag byte_size",
+                1,
+                np.mean([frag.byte_size for frag in lod.fragments]),
+            )
+            for j, frag in enumerate(lod.fragments):
+                print(
+                    i,
+                    j,
+                    frag.position,
+                    frag.position + lod.chunk_shape,
+                    frag.byte_offset,
+                    frag.byte_offset + frag.byte_size,
+                )
+
+
+asyncio.run(main())

--- a/wkconnect/backends/neuroglancer/meshes.py
+++ b/wkconnect/backends/neuroglancer/meshes.py
@@ -1,14 +1,12 @@
-import asyncio
-from aiohttp import ClientSession
 from dataclasses import dataclass, replace
 import numpy as np
-from async_lru import alru_cache
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, cast
+from typing import Any, List, Tuple
+import DracoPy
+from stl import Mesh
+from io import BytesIO
 
-
-from .sharding import MinishardInfo, ShardingInfo
-from ...utils.types import Vec3D, Vec3Df
-from wkconnect.backends.neuroglancer import sharding
+from .sharding import ShardingInfo
+from ...utils.types import Vec3Df
 
 
 @dataclass(frozen=True)
@@ -32,7 +30,9 @@ class Meshfile:
     grid_origin: Vec3Df
     lods: List[MeshfileLod]
 
-    def fragment_offset_and_shape(self, lod: int, fragment: int):
+    def fragment_offset_and_shape(
+        self, lod: int, fragment: int
+    ) -> Tuple[Vec3Df, Vec3Df, Vec3Df]:
         return (
             self.grid_origin
             + self.lods[lod].fragments[fragment].position
@@ -46,6 +46,18 @@ class Meshfile:
             self.chunk_shape * self.lods[lod].scale,
         )
 
+    def decode_data(self, buf: bytes) -> bytes:
+        mesh_obj = DracoPy.decode_buffer_to_mesh(buf)
+        vertices = np.array(mesh_obj.points, dtype="f4").reshape((-1, 3))
+        faces = np.array(mesh_obj.faces, dtype="<u4").reshape((-1, 3))
+        stl_mesh = Mesh(np.zeros(faces.shape[0], dtype=Mesh.dtype))
+        for i, f in enumerate(faces):
+            for j in range(3):
+                stl_mesh.vectors[i][j] = vertices[f[j], :]
+        out_buf = BytesIO()
+        stl_mesh.save("mesh.stl", out_buf, update_normals=True)
+        return out_buf.getvalue()
+
 
 @dataclass(frozen=True)
 class MeshInfo:
@@ -54,7 +66,18 @@ class MeshInfo:
     vertex_quantization_bits: int
     lod_scale_multiplier: int = 1
 
-    def parse_meshfile(self, buf: bytes, byte_offset: int):
+    @staticmethod
+    def parse(info_json: Any) -> "MeshInfo":
+        print(info_json)
+        assert info_json["@type"] == "neuroglancer_multilod_draco"
+        return MeshInfo(
+            sharding=ShardingInfo.parse(info_json["sharding"]),
+            transform=np.array(info_json["transform"], dtype="f4").reshape((4, 3)),
+            vertex_quantization_bits=info_json["vertex_quantization_bits"],
+            lod_scale_multiplier=info_json["lod_scale_multiplier"],
+        )
+
+    def parse_meshfile(self, buf: bytes, byte_offset: int) -> Meshfile:
         p = 0
         chunk_shape = np.frombuffer(buf[p : p + 12], dtype="f4").copy()
         p += 12
@@ -102,7 +125,6 @@ class MeshInfo:
 
                 fragments = []
                 for i in range(num_fragments_per_lod[lod]):
-                    position = fragment_positions[i]
                     global_position = (
                         grid_origin
                         + fragment_positions[i] * chunk_shape * lod_scales[lod]
@@ -145,115 +167,3 @@ class MeshInfo:
                 for lod in lods
             ],
         )
-
-
-async def __read_ranged_data(
-    http_client: ClientSession, url: str, range: Tuple[int, int]
-) -> bytes:
-    if range[0] == range[1]:
-        return b""
-    headers = {"Range": f"bytes={int(range[0])}-{int(range[1]-1)}"}
-    async with await http_client.get(url, headers=headers) as r:
-        r.raise_for_status()
-        response_buffer = await r.read()
-    return response_buffer
-
-
-@alru_cache(maxsize=2 ** 12, cache_exceptions=False)
-async def __read_shard_index(
-    http_client: ClientSession, shard_url: str, sharding_info: ShardingInfo
-) -> np.ndarray:
-    shard_index_range = sharding_info.get_shard_index_range()
-    print("shard_index_range", shard_index_range)
-    index = sharding_info.parse_shard_index(
-        await __read_ranged_data(http_client, shard_url, shard_index_range)
-    )
-    return index
-
-
-@alru_cache(maxsize=2 ** 12, cache_exceptions=False)
-async def __read_minishard_index(
-    http_client: ClientSession,
-    shard_url: str,
-    sharding_info: ShardingInfo,
-    minishard_info: MinishardInfo,
-) -> np.ndarray:
-    shard_index = await __read_shard_index(http_client, shard_url, sharding_info)
-    minishard_index_range = sharding_info.get_minishard_index_range(
-        minishard_info.minishard_number, shard_index
-    )
-    print("minishare_index_range", minishard_index_range)
-    buf = await __read_ranged_data(http_client, shard_url, minishard_index_range)
-    index = sharding_info.parse_minishard_index(buf)
-    return index
-
-
-async def __read_sharded_mesh(
-    http_client: ClientSession, source_url: str, mesh_info: MeshInfo, segment_id: int
-) -> Optional[Meshfile]:
-    sharding_info = mesh_info.sharding
-    chunk_id = np.uint64(segment_id)
-    minishard_info = sharding_info.get_minishard_info(chunk_id)
-    shard_url = f"{source_url}%2F{sharding_info.format_shard_for_url(minishard_info)}.shard?alt=media"
-    print("shard_url", shard_url)
-    minishard_index = await __read_minishard_index(
-        http_client, shard_url, sharding_info, minishard_info
-    )
-    chunk_range = sharding_info.get_chunk_range(chunk_id, minishard_index)
-    print("chunk_range", chunk_range)
-    if chunk_range is None:
-        return None
-    buf = sharding_info.parse_chunk(
-        await __read_ranged_data(http_client, shard_url, chunk_range)
-    )
-
-    return mesh_info.parse_meshfile(buf, chunk_range[0])
-
-
-async def main():
-    async with ClientSession(raise_for_status=True) as http_client:
-        # segment_id = 673639143
-        segment_id = 977667682
-
-        info = MeshInfo(
-            sharding=ShardingInfo(
-                dataset_size=Vec3D(0, 0, 0),
-                chunk_size=Vec3D(0, 0, 0),
-                preshift_bits=6,
-                minishard_bits=8,
-                minishard_index_encoding="gzip",
-                shard_bits=10,
-                data_encoding="gzip",
-                hashfn="murmurhash3_x86_128",
-            ),
-            lod_scale_multiplier=1,
-            transform=np.array([[16, 0, 0, 0], [0, 16, 0, 0], [0, 0, 16, 0]]),
-            vertex_quantization_bits=16,
-        )
-
-        mesh = await __read_sharded_mesh(
-            http_client,
-            "https://www.googleapis.com/storage/v1/b/neuroglancer-janelia-flyem-hemibrain/o/v1.0%2Fsegmentation%2Fmesh",
-            info,
-            segment_id,
-        )
-
-        print(mesh)
-        for i, lod in enumerate(mesh.lods):
-            print(
-                "Mean frag byte_size",
-                1,
-                np.mean([frag.byte_size for frag in lod.fragments]),
-            )
-            for j, frag in enumerate(lod.fragments):
-                print(
-                    i,
-                    j,
-                    frag.position,
-                    frag.position + lod.chunk_shape,
-                    frag.byte_offset,
-                    frag.byte_offset + frag.byte_size,
-                )
-
-
-asyncio.run(main())

--- a/wkconnect/backends/neuroglancer/mmh3.py
+++ b/wkconnect/backends/neuroglancer/mmh3.py
@@ -1,0 +1,470 @@
+"""
+pymmh3 was written by Fredrik Kihlander and enhanced by Swapnil Gusani, and is placed in the public
+domain. The authors hereby disclaim copyright to this source code.
+pure python implementation of the murmur3 hash algorithm
+https://code.google.com/p/smhasher/wiki/MurmurHash3
+This was written for the times when you do not want to compile c-code and install modules,
+and you only want a drop-in murmur3 implementation.
+As this is purely python it is FAR from performant and if performance is anything that is needed
+a proper c-module is suggested!
+This module is written to have the same format as mmh3 python package found here for simple conversions:
+https://pypi.python.org/pypi/mmh3/2.3.1
+"""
+
+import sys as _sys
+
+if _sys.version_info > (3, 0):
+
+    def xrange(a, b, c):
+        return range(a, b, c)
+
+    def xencode(x):
+        if isinstance(x, bytes) or isinstance(x, bytearray):
+            return x
+        else:
+            return x.encode()
+
+
+else:
+
+    def xencode(x):
+        return x
+
+
+del _sys
+
+
+def hash(key, seed=0x0):
+    """ Implements 32bit murmur3 hash. """
+
+    key = bytearray(xencode(key))
+
+    def fmix(h):
+        h ^= h >> 16
+        h = (h * 0x85EBCA6B) & 0xFFFFFFFF
+        h ^= h >> 13
+        h = (h * 0xC2B2AE35) & 0xFFFFFFFF
+        h ^= h >> 16
+        return h
+
+    length = len(key)
+    nblocks = int(length / 4)
+
+    h1 = seed
+
+    c1 = 0xCC9E2D51
+    c2 = 0x1B873593
+
+    # body
+    for block_start in xrange(0, nblocks * 4, 4):
+        # ??? big endian?
+        k1 = (
+            key[block_start + 3] << 24
+            | key[block_start + 2] << 16
+            | key[block_start + 1] << 8
+            | key[block_start + 0]
+        )
+
+        k1 = (c1 * k1) & 0xFFFFFFFF
+        k1 = (k1 << 15 | k1 >> 17) & 0xFFFFFFFF  # inlined ROTL32
+        k1 = (c2 * k1) & 0xFFFFFFFF
+
+        h1 ^= k1
+        h1 = (h1 << 13 | h1 >> 19) & 0xFFFFFFFF  # inlined ROTL32
+        h1 = (h1 * 5 + 0xE6546B64) & 0xFFFFFFFF
+
+    # tail
+    tail_index = nblocks * 4
+    k1 = 0
+    tail_size = length & 3
+
+    if tail_size >= 3:
+        k1 ^= key[tail_index + 2] << 16
+    if tail_size >= 2:
+        k1 ^= key[tail_index + 1] << 8
+    if tail_size >= 1:
+        k1 ^= key[tail_index + 0]
+
+    if tail_size > 0:
+        k1 = (k1 * c1) & 0xFFFFFFFF
+        k1 = (k1 << 15 | k1 >> 17) & 0xFFFFFFFF  # inlined ROTL32
+        k1 = (k1 * c2) & 0xFFFFFFFF
+        h1 ^= k1
+
+    # finalization
+    unsigned_val = fmix(h1 ^ length)
+    if unsigned_val & 0x80000000 == 0:
+        return unsigned_val
+    else:
+        return -((unsigned_val ^ 0xFFFFFFFF) + 1)
+
+
+def hash128(key, seed=0x0, x64arch=True):
+    """ Implements 128bit murmur3 hash. """
+
+    def hash128_x64(key, seed):
+        """ Implements 128bit murmur3 hash for x64. """
+
+        def fmix(k):
+            k ^= k >> 33
+            k = (k * 0xFF51AFD7ED558CCD) & 0xFFFFFFFFFFFFFFFF
+            k ^= k >> 33
+            k = (k * 0xC4CEB9FE1A85EC53) & 0xFFFFFFFFFFFFFFFF
+            k ^= k >> 33
+            return k
+
+        length = len(key)
+        nblocks = int(length / 16)
+
+        h1 = seed
+        h2 = seed
+
+        c1 = 0x87C37B91114253D5
+        c2 = 0x4CF5AD432745937F
+
+        # body
+        for block_start in xrange(0, nblocks * 8, 8):
+            # ??? big endian?
+            k1 = (
+                key[2 * block_start + 7] << 56
+                | key[2 * block_start + 6] << 48
+                | key[2 * block_start + 5] << 40
+                | key[2 * block_start + 4] << 32
+                | key[2 * block_start + 3] << 24
+                | key[2 * block_start + 2] << 16
+                | key[2 * block_start + 1] << 8
+                | key[2 * block_start + 0]
+            )
+
+            k2 = (
+                key[2 * block_start + 15] << 56
+                | key[2 * block_start + 14] << 48
+                | key[2 * block_start + 13] << 40
+                | key[2 * block_start + 12] << 32
+                | key[2 * block_start + 11] << 24
+                | key[2 * block_start + 10] << 16
+                | key[2 * block_start + 9] << 8
+                | key[2 * block_start + 8]
+            )
+
+            k1 = (c1 * k1) & 0xFFFFFFFFFFFFFFFF
+            k1 = (k1 << 31 | k1 >> 33) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
+            k1 = (c2 * k1) & 0xFFFFFFFFFFFFFFFF
+            h1 ^= k1
+
+            h1 = (h1 << 27 | h1 >> 37) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
+            h1 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
+            h1 = (h1 * 5 + 0x52DCE729) & 0xFFFFFFFFFFFFFFFF
+
+            k2 = (c2 * k2) & 0xFFFFFFFFFFFFFFFF
+            k2 = (k2 << 33 | k2 >> 31) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
+            k2 = (c1 * k2) & 0xFFFFFFFFFFFFFFFF
+            h2 ^= k2
+
+            h2 = (h2 << 31 | h2 >> 33) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
+            h2 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
+            h2 = (h2 * 5 + 0x38495AB5) & 0xFFFFFFFFFFFFFFFF
+
+        # tail
+        tail_index = nblocks * 16
+        k1 = 0
+        k2 = 0
+        tail_size = length & 15
+
+        if tail_size >= 15:
+            k2 ^= key[tail_index + 14] << 48
+        if tail_size >= 14:
+            k2 ^= key[tail_index + 13] << 40
+        if tail_size >= 13:
+            k2 ^= key[tail_index + 12] << 32
+        if tail_size >= 12:
+            k2 ^= key[tail_index + 11] << 24
+        if tail_size >= 11:
+            k2 ^= key[tail_index + 10] << 16
+        if tail_size >= 10:
+            k2 ^= key[tail_index + 9] << 8
+        if tail_size >= 9:
+            k2 ^= key[tail_index + 8]
+
+        if tail_size > 8:
+            k2 = (k2 * c2) & 0xFFFFFFFFFFFFFFFF
+            k2 = (k2 << 33 | k2 >> 31) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
+            k2 = (k2 * c1) & 0xFFFFFFFFFFFFFFFF
+            h2 ^= k2
+
+        if tail_size >= 8:
+            k1 ^= key[tail_index + 7] << 56
+        if tail_size >= 7:
+            k1 ^= key[tail_index + 6] << 48
+        if tail_size >= 6:
+            k1 ^= key[tail_index + 5] << 40
+        if tail_size >= 5:
+            k1 ^= key[tail_index + 4] << 32
+        if tail_size >= 4:
+            k1 ^= key[tail_index + 3] << 24
+        if tail_size >= 3:
+            k1 ^= key[tail_index + 2] << 16
+        if tail_size >= 2:
+            k1 ^= key[tail_index + 1] << 8
+        if tail_size >= 1:
+            k1 ^= key[tail_index + 0]
+
+        if tail_size > 0:
+            k1 = (k1 * c1) & 0xFFFFFFFFFFFFFFFF
+            k1 = (k1 << 31 | k1 >> 33) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
+            k1 = (k1 * c2) & 0xFFFFFFFFFFFFFFFF
+            h1 ^= k1
+
+        # finalization
+        h1 ^= length
+        h2 ^= length
+
+        h1 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
+        h2 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
+
+        h1 = fmix(h1)
+        h2 = fmix(h2)
+
+        h1 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
+        h2 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
+
+        return h2 << 64 | h1
+
+    def hash128_x86(key, seed):
+        """ Implements 128bit murmur3 hash for x86. """
+
+        def fmix(h):
+            h ^= h >> 16
+            h = (h * 0x85EBCA6B) & 0xFFFFFFFF
+            h ^= h >> 13
+            h = (h * 0xC2B2AE35) & 0xFFFFFFFF
+            h ^= h >> 16
+            return h
+
+        length = len(key)
+        nblocks = int(length / 16)
+
+        h1 = seed
+        h2 = seed
+        h3 = seed
+        h4 = seed
+
+        c1 = 0x239B961B
+        c2 = 0xAB0E9789
+        c3 = 0x38B34AE5
+        c4 = 0xA1E38B93
+
+        # body
+        for block_start in xrange(0, nblocks * 16, 16):
+            k1 = (
+                key[block_start + 3] << 24
+                | key[block_start + 2] << 16
+                | key[block_start + 1] << 8
+                | key[block_start + 0]
+            )
+
+            k2 = (
+                key[block_start + 7] << 24
+                | key[block_start + 6] << 16
+                | key[block_start + 5] << 8
+                | key[block_start + 4]
+            )
+
+            k3 = (
+                key[block_start + 11] << 24
+                | key[block_start + 10] << 16
+                | key[block_start + 9] << 8
+                | key[block_start + 8]
+            )
+
+            k4 = (
+                key[block_start + 15] << 24
+                | key[block_start + 14] << 16
+                | key[block_start + 13] << 8
+                | key[block_start + 12]
+            )
+
+            k1 = (c1 * k1) & 0xFFFFFFFF
+            k1 = (k1 << 15 | k1 >> 17) & 0xFFFFFFFF  # inlined ROTL32
+            k1 = (c2 * k1) & 0xFFFFFFFF
+            h1 ^= k1
+
+            h1 = (h1 << 19 | h1 >> 13) & 0xFFFFFFFF  # inlined ROTL32
+            h1 = (h1 + h2) & 0xFFFFFFFF
+            h1 = (h1 * 5 + 0x561CCD1B) & 0xFFFFFFFF
+
+            k2 = (c2 * k2) & 0xFFFFFFFF
+            k2 = (k2 << 16 | k2 >> 16) & 0xFFFFFFFF  # inlined ROTL32
+            k2 = (c3 * k2) & 0xFFFFFFFF
+            h2 ^= k2
+
+            h2 = (h2 << 17 | h2 >> 15) & 0xFFFFFFFF  # inlined ROTL32
+            h2 = (h2 + h3) & 0xFFFFFFFF
+            h2 = (h2 * 5 + 0x0BCAA747) & 0xFFFFFFFF
+
+            k3 = (c3 * k3) & 0xFFFFFFFF
+            k3 = (k3 << 17 | k3 >> 15) & 0xFFFFFFFF  # inlined ROTL32
+            k3 = (c4 * k3) & 0xFFFFFFFF
+            h3 ^= k3
+
+            h3 = (h3 << 15 | h3 >> 17) & 0xFFFFFFFF  # inlined ROTL32
+            h3 = (h3 + h4) & 0xFFFFFFFF
+            h3 = (h3 * 5 + 0x96CD1C35) & 0xFFFFFFFF
+
+            k4 = (c4 * k4) & 0xFFFFFFFF
+            k4 = (k4 << 18 | k4 >> 14) & 0xFFFFFFFF  # inlined ROTL32
+            k4 = (c1 * k4) & 0xFFFFFFFF
+            h4 ^= k4
+
+            h4 = (h4 << 13 | h4 >> 19) & 0xFFFFFFFF  # inlined ROTL32
+            h4 = (h1 + h4) & 0xFFFFFFFF
+            h4 = (h4 * 5 + 0x32AC3B17) & 0xFFFFFFFF
+
+        # tail
+        tail_index = nblocks * 16
+        k1 = 0
+        k2 = 0
+        k3 = 0
+        k4 = 0
+        tail_size = length & 15
+
+        if tail_size >= 15:
+            k4 ^= key[tail_index + 14] << 16
+        if tail_size >= 14:
+            k4 ^= key[tail_index + 13] << 8
+        if tail_size >= 13:
+            k4 ^= key[tail_index + 12]
+
+        if tail_size > 12:
+            k4 = (k4 * c4) & 0xFFFFFFFF
+            k4 = (k4 << 18 | k4 >> 14) & 0xFFFFFFFF  # inlined ROTL32
+            k4 = (k4 * c1) & 0xFFFFFFFF
+            h4 ^= k4
+
+        if tail_size >= 12:
+            k3 ^= key[tail_index + 11] << 24
+        if tail_size >= 11:
+            k3 ^= key[tail_index + 10] << 16
+        if tail_size >= 10:
+            k3 ^= key[tail_index + 9] << 8
+        if tail_size >= 9:
+            k3 ^= key[tail_index + 8]
+
+        if tail_size > 8:
+            k3 = (k3 * c3) & 0xFFFFFFFF
+            k3 = (k3 << 17 | k3 >> 15) & 0xFFFFFFFF  # inlined ROTL32
+            k3 = (k3 * c4) & 0xFFFFFFFF
+            h3 ^= k3
+
+        if tail_size >= 8:
+            k2 ^= key[tail_index + 7] << 24
+        if tail_size >= 7:
+            k2 ^= key[tail_index + 6] << 16
+        if tail_size >= 6:
+            k2 ^= key[tail_index + 5] << 8
+        if tail_size >= 5:
+            k2 ^= key[tail_index + 4]
+
+        if tail_size > 4:
+            k2 = (k2 * c2) & 0xFFFFFFFF
+            k2 = (k2 << 16 | k2 >> 16) & 0xFFFFFFFF  # inlined ROTL32
+            k2 = (k2 * c3) & 0xFFFFFFFF
+            h2 ^= k2
+
+        if tail_size >= 4:
+            k1 ^= key[tail_index + 3] << 24
+        if tail_size >= 3:
+            k1 ^= key[tail_index + 2] << 16
+        if tail_size >= 2:
+            k1 ^= key[tail_index + 1] << 8
+        if tail_size >= 1:
+            k1 ^= key[tail_index + 0]
+
+        if tail_size > 0:
+            k1 = (k1 * c1) & 0xFFFFFFFF
+            k1 = (k1 << 15 | k1 >> 17) & 0xFFFFFFFF  # inlined ROTL32
+            k1 = (k1 * c2) & 0xFFFFFFFF
+            h1 ^= k1
+
+        # finalization
+        h1 ^= length
+        h2 ^= length
+        h3 ^= length
+        h4 ^= length
+
+        h1 = (h1 + h2) & 0xFFFFFFFF
+        h1 = (h1 + h3) & 0xFFFFFFFF
+        h1 = (h1 + h4) & 0xFFFFFFFF
+        h2 = (h1 + h2) & 0xFFFFFFFF
+        h3 = (h1 + h3) & 0xFFFFFFFF
+        h4 = (h1 + h4) & 0xFFFFFFFF
+
+        h1 = fmix(h1)
+        h2 = fmix(h2)
+        h3 = fmix(h3)
+        h4 = fmix(h4)
+
+        h1 = (h1 + h2) & 0xFFFFFFFF
+        h1 = (h1 + h3) & 0xFFFFFFFF
+        h1 = (h1 + h4) & 0xFFFFFFFF
+        h2 = (h1 + h2) & 0xFFFFFFFF
+        h3 = (h1 + h3) & 0xFFFFFFFF
+        h4 = (h1 + h4) & 0xFFFFFFFF
+
+        return h4 << 96 | h3 << 64 | h2 << 32 | h1
+
+    key = bytearray(xencode(key))
+
+    if x64arch:
+        return hash128_x64(key, seed)
+    else:
+        return hash128_x86(key, seed)
+
+
+def hash64(key, seed=0x0, x64arch=True):
+    """ Implements 64bit murmur3 hash. Returns a tuple. """
+
+    hash_128 = hash128(key, seed, x64arch)
+
+    unsigned_val1 = hash_128 & 0xFFFFFFFFFFFFFFFF
+    if unsigned_val1 & 0x8000000000000000 == 0:
+        signed_val1 = unsigned_val1
+    else:
+        signed_val1 = -((unsigned_val1 ^ 0xFFFFFFFFFFFFFFFF) + 1)
+
+    unsigned_val2 = (hash_128 >> 64) & 0xFFFFFFFFFFFFFFFF
+    if unsigned_val2 & 0x8000000000000000 == 0:
+        signed_val2 = unsigned_val2
+    else:
+        signed_val2 = -((unsigned_val2 ^ 0xFFFFFFFFFFFFFFFF) + 1)
+
+    return (int(signed_val1), int(signed_val2))
+
+
+def hash_bytes(key, seed=0x0, x64arch=True):
+    """ Implements 128bit murmur3 hash. Returns a byte string. """
+
+    hash_128 = hash128(key, seed, x64arch)
+
+    bytestring = ""
+
+    for i in xrange(0, 16, 1):
+        lsbyte = hash_128 & 0xFF
+        bytestring = bytestring + str(chr(lsbyte))
+        hash_128 = hash_128 >> 8
+
+    return bytestring
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser("pymurmur3", 'pymurmur [options] "string to hash"')
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("strings", default=[], nargs="+")
+
+    opts = parser.parse_args()
+
+    for str_to_hash in opts.strings:
+        sys.stdout.write('"%s" = 0x%08X\n' % (str_to_hash, hash(str_to_hash)))
+

--- a/wkconnect/backends/neuroglancer/mmh3.py
+++ b/wkconnect/backends/neuroglancer/mmh3.py
@@ -12,27 +12,26 @@ https://pypi.python.org/pypi/mmh3/2.3.1
 """
 
 
-from typing import Tuple
+from typing import Tuple, Union
 
 
-def _xrange(a, b, c):
-    return range(a, b, c)
-
-
-def _xencode(x):
-    if isinstance(x, bytes) or isinstance(x, bytearray):
+def _xencode(x: Union[bytes, bytearray, str]) -> bytearray:
+    if isinstance(x, bytearray):
         return x
+    elif isinstance(x, bytes):
+        return bytearray(x)
     else:
-        return x.encode()
+        return bytearray(x.encode())
 
 
-def hash128(key: int, seed: int = 0x0) -> int:
+# flake8: noqa: C901
+def hash128(key: bytes, seed: int = 0x0) -> int:
     """ Implements 128bit murmur3 hash. """
 
-    def hash128_x86(key: int, seed: int) -> int:
+    def hash128_x86(key: bytes, seed: int) -> int:
         """ Implements 128bit murmur3 hash for x86. """
 
-        def fmix(h):
+        def fmix(h: int) -> int:
             h ^= h >> 16
             h = (h * 0x85EBCA6B) & 0xFFFFFFFF
             h ^= h >> 13
@@ -54,7 +53,7 @@ def hash128(key: int, seed: int = 0x0) -> int:
         c4 = 0xA1E38B93
 
         # body
-        for block_start in _xrange(0, nblocks * 16, 16):
+        for block_start in range(0, nblocks * 16, 16):
             k1 = (
                 key[block_start + 3] << 24
                 | key[block_start + 2] << 16
@@ -212,12 +211,12 @@ def hash128(key: int, seed: int = 0x0) -> int:
 
         return h4 << 96 | h3 << 64 | h2 << 32 | h1
 
-    key = bytearray(_xencode(key))
+    key = _xencode(key)
 
     return hash128_x86(key, seed)
 
 
-def hash64(key: int, seed: int = 0x0) -> Tuple[int, int]:
+def hash64(key: bytes, seed: int = 0x0) -> Tuple[int, int]:
     """ Implements 64bit murmur3 hash. Returns a tuple. """
 
     hash_128 = hash128(key, seed)

--- a/wkconnect/backends/neuroglancer/mmh3.py
+++ b/wkconnect/backends/neuroglancer/mmh3.py
@@ -11,226 +11,25 @@ This module is written to have the same format as mmh3 python package found here
 https://pypi.python.org/pypi/mmh3/2.3.1
 """
 
-import sys as _sys
 
-if _sys.version_info > (3, 0):
-
-    def xrange(a, b, c):
-        return range(a, b, c)
-
-    def xencode(x):
-        if isinstance(x, bytes) or isinstance(x, bytearray):
-            return x
-        else:
-            return x.encode()
+from typing import Tuple
 
 
-else:
+def _xrange(a, b, c):
+    return range(a, b, c)
 
-    def xencode(x):
+
+def _xencode(x):
+    if isinstance(x, bytes) or isinstance(x, bytearray):
         return x
-
-
-del _sys
-
-
-def hash(key, seed=0x0):
-    """ Implements 32bit murmur3 hash. """
-
-    key = bytearray(xencode(key))
-
-    def fmix(h):
-        h ^= h >> 16
-        h = (h * 0x85EBCA6B) & 0xFFFFFFFF
-        h ^= h >> 13
-        h = (h * 0xC2B2AE35) & 0xFFFFFFFF
-        h ^= h >> 16
-        return h
-
-    length = len(key)
-    nblocks = int(length / 4)
-
-    h1 = seed
-
-    c1 = 0xCC9E2D51
-    c2 = 0x1B873593
-
-    # body
-    for block_start in xrange(0, nblocks * 4, 4):
-        # ??? big endian?
-        k1 = (
-            key[block_start + 3] << 24
-            | key[block_start + 2] << 16
-            | key[block_start + 1] << 8
-            | key[block_start + 0]
-        )
-
-        k1 = (c1 * k1) & 0xFFFFFFFF
-        k1 = (k1 << 15 | k1 >> 17) & 0xFFFFFFFF  # inlined ROTL32
-        k1 = (c2 * k1) & 0xFFFFFFFF
-
-        h1 ^= k1
-        h1 = (h1 << 13 | h1 >> 19) & 0xFFFFFFFF  # inlined ROTL32
-        h1 = (h1 * 5 + 0xE6546B64) & 0xFFFFFFFF
-
-    # tail
-    tail_index = nblocks * 4
-    k1 = 0
-    tail_size = length & 3
-
-    if tail_size >= 3:
-        k1 ^= key[tail_index + 2] << 16
-    if tail_size >= 2:
-        k1 ^= key[tail_index + 1] << 8
-    if tail_size >= 1:
-        k1 ^= key[tail_index + 0]
-
-    if tail_size > 0:
-        k1 = (k1 * c1) & 0xFFFFFFFF
-        k1 = (k1 << 15 | k1 >> 17) & 0xFFFFFFFF  # inlined ROTL32
-        k1 = (k1 * c2) & 0xFFFFFFFF
-        h1 ^= k1
-
-    # finalization
-    unsigned_val = fmix(h1 ^ length)
-    if unsigned_val & 0x80000000 == 0:
-        return unsigned_val
     else:
-        return -((unsigned_val ^ 0xFFFFFFFF) + 1)
+        return x.encode()
 
 
-def hash128(key, seed=0x0, x64arch=True):
+def hash128(key: int, seed: int = 0x0) -> int:
     """ Implements 128bit murmur3 hash. """
 
-    def hash128_x64(key, seed):
-        """ Implements 128bit murmur3 hash for x64. """
-
-        def fmix(k):
-            k ^= k >> 33
-            k = (k * 0xFF51AFD7ED558CCD) & 0xFFFFFFFFFFFFFFFF
-            k ^= k >> 33
-            k = (k * 0xC4CEB9FE1A85EC53) & 0xFFFFFFFFFFFFFFFF
-            k ^= k >> 33
-            return k
-
-        length = len(key)
-        nblocks = int(length / 16)
-
-        h1 = seed
-        h2 = seed
-
-        c1 = 0x87C37B91114253D5
-        c2 = 0x4CF5AD432745937F
-
-        # body
-        for block_start in xrange(0, nblocks * 8, 8):
-            # ??? big endian?
-            k1 = (
-                key[2 * block_start + 7] << 56
-                | key[2 * block_start + 6] << 48
-                | key[2 * block_start + 5] << 40
-                | key[2 * block_start + 4] << 32
-                | key[2 * block_start + 3] << 24
-                | key[2 * block_start + 2] << 16
-                | key[2 * block_start + 1] << 8
-                | key[2 * block_start + 0]
-            )
-
-            k2 = (
-                key[2 * block_start + 15] << 56
-                | key[2 * block_start + 14] << 48
-                | key[2 * block_start + 13] << 40
-                | key[2 * block_start + 12] << 32
-                | key[2 * block_start + 11] << 24
-                | key[2 * block_start + 10] << 16
-                | key[2 * block_start + 9] << 8
-                | key[2 * block_start + 8]
-            )
-
-            k1 = (c1 * k1) & 0xFFFFFFFFFFFFFFFF
-            k1 = (k1 << 31 | k1 >> 33) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
-            k1 = (c2 * k1) & 0xFFFFFFFFFFFFFFFF
-            h1 ^= k1
-
-            h1 = (h1 << 27 | h1 >> 37) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
-            h1 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
-            h1 = (h1 * 5 + 0x52DCE729) & 0xFFFFFFFFFFFFFFFF
-
-            k2 = (c2 * k2) & 0xFFFFFFFFFFFFFFFF
-            k2 = (k2 << 33 | k2 >> 31) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
-            k2 = (c1 * k2) & 0xFFFFFFFFFFFFFFFF
-            h2 ^= k2
-
-            h2 = (h2 << 31 | h2 >> 33) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
-            h2 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
-            h2 = (h2 * 5 + 0x38495AB5) & 0xFFFFFFFFFFFFFFFF
-
-        # tail
-        tail_index = nblocks * 16
-        k1 = 0
-        k2 = 0
-        tail_size = length & 15
-
-        if tail_size >= 15:
-            k2 ^= key[tail_index + 14] << 48
-        if tail_size >= 14:
-            k2 ^= key[tail_index + 13] << 40
-        if tail_size >= 13:
-            k2 ^= key[tail_index + 12] << 32
-        if tail_size >= 12:
-            k2 ^= key[tail_index + 11] << 24
-        if tail_size >= 11:
-            k2 ^= key[tail_index + 10] << 16
-        if tail_size >= 10:
-            k2 ^= key[tail_index + 9] << 8
-        if tail_size >= 9:
-            k2 ^= key[tail_index + 8]
-
-        if tail_size > 8:
-            k2 = (k2 * c2) & 0xFFFFFFFFFFFFFFFF
-            k2 = (k2 << 33 | k2 >> 31) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
-            k2 = (k2 * c1) & 0xFFFFFFFFFFFFFFFF
-            h2 ^= k2
-
-        if tail_size >= 8:
-            k1 ^= key[tail_index + 7] << 56
-        if tail_size >= 7:
-            k1 ^= key[tail_index + 6] << 48
-        if tail_size >= 6:
-            k1 ^= key[tail_index + 5] << 40
-        if tail_size >= 5:
-            k1 ^= key[tail_index + 4] << 32
-        if tail_size >= 4:
-            k1 ^= key[tail_index + 3] << 24
-        if tail_size >= 3:
-            k1 ^= key[tail_index + 2] << 16
-        if tail_size >= 2:
-            k1 ^= key[tail_index + 1] << 8
-        if tail_size >= 1:
-            k1 ^= key[tail_index + 0]
-
-        if tail_size > 0:
-            k1 = (k1 * c1) & 0xFFFFFFFFFFFFFFFF
-            k1 = (k1 << 31 | k1 >> 33) & 0xFFFFFFFFFFFFFFFF  # inlined ROTL64
-            k1 = (k1 * c2) & 0xFFFFFFFFFFFFFFFF
-            h1 ^= k1
-
-        # finalization
-        h1 ^= length
-        h2 ^= length
-
-        h1 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
-        h2 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
-
-        h1 = fmix(h1)
-        h2 = fmix(h2)
-
-        h1 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
-        h2 = (h1 + h2) & 0xFFFFFFFFFFFFFFFF
-
-        return h2 << 64 | h1
-
-    def hash128_x86(key, seed):
+    def hash128_x86(key: int, seed: int) -> int:
         """ Implements 128bit murmur3 hash for x86. """
 
         def fmix(h):
@@ -255,7 +54,7 @@ def hash128(key, seed=0x0, x64arch=True):
         c4 = 0xA1E38B93
 
         # body
-        for block_start in xrange(0, nblocks * 16, 16):
+        for block_start in _xrange(0, nblocks * 16, 16):
             k1 = (
                 key[block_start + 3] << 24
                 | key[block_start + 2] << 16
@@ -413,18 +212,15 @@ def hash128(key, seed=0x0, x64arch=True):
 
         return h4 << 96 | h3 << 64 | h2 << 32 | h1
 
-    key = bytearray(xencode(key))
+    key = bytearray(_xencode(key))
 
-    if x64arch:
-        return hash128_x64(key, seed)
-    else:
-        return hash128_x86(key, seed)
+    return hash128_x86(key, seed)
 
 
-def hash64(key, seed=0x0, x64arch=True):
+def hash64(key: int, seed: int = 0x0) -> Tuple[int, int]:
     """ Implements 64bit murmur3 hash. Returns a tuple. """
 
-    hash_128 = hash128(key, seed, x64arch)
+    hash_128 = hash128(key, seed)
 
     unsigned_val1 = hash_128 & 0xFFFFFFFFFFFFFFFF
     if unsigned_val1 & 0x8000000000000000 == 0:
@@ -439,32 +235,3 @@ def hash64(key, seed=0x0, x64arch=True):
         signed_val2 = -((unsigned_val2 ^ 0xFFFFFFFFFFFFFFFF) + 1)
 
     return (int(signed_val1), int(signed_val2))
-
-
-def hash_bytes(key, seed=0x0, x64arch=True):
-    """ Implements 128bit murmur3 hash. Returns a byte string. """
-
-    hash_128 = hash128(key, seed, x64arch)
-
-    bytestring = ""
-
-    for i in xrange(0, 16, 1):
-        lsbyte = hash_128 & 0xFF
-        bytestring = bytestring + str(chr(lsbyte))
-        hash_128 = hash_128 >> 8
-
-    return bytestring
-
-
-if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser("pymurmur3", 'pymurmur [options] "string to hash"')
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("strings", default=[], nargs="+")
-
-    opts = parser.parse_args()
-
-    for str_to_hash in opts.strings:
-        sys.stdout.write('"%s" = 0x%08X\n' % (str_to_hash, hash(str_to_hash)))
-

--- a/wkconnect/backends/neuroglancer/models.py
+++ b/wkconnect/backends/neuroglancer/models.py
@@ -3,15 +3,14 @@ from typing import Dict, Optional, Tuple
 
 from gcloud.aio.auth import Token
 
-
 from ...utils.types import Box3D, Vec3D, Vec3Df
 from ...webknossos.models import BoundingBox
 from ...webknossos.models import DataLayer as WkDataLayer
 from ...webknossos.models import DataSource as WkDataSource
 from ...webknossos.models import DataSourceId as WkDataSourceId
 from ..backend import DatasetInfo
-from .sharding import ShardingInfo
 from .meshes import MeshInfo
+from .sharding import ShardingInfo
 
 
 @dataclass(frozen=True)

--- a/wkconnect/backends/neuroglancer/models.py
+++ b/wkconnect/backends/neuroglancer/models.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional, Tuple
 
 from gcloud.aio.auth import Token
 
+
 from ...utils.types import Box3D, Vec3D, Vec3Df
 from ...webknossos.models import BoundingBox
 from ...webknossos.models import DataLayer as WkDataLayer
@@ -10,6 +11,7 @@ from ...webknossos.models import DataSource as WkDataSource
 from ...webknossos.models import DataSourceId as WkDataSourceId
 from ..backend import DatasetInfo
 from .sharding import ShardingInfo
+from .meshes import MeshInfo
 
 
 @dataclass(frozen=True)
@@ -46,6 +48,7 @@ class Layer:
     scales: Tuple[Scale, ...]
     resolution: Vec3Df
     type: str
+    mesh: Optional[MeshInfo] = None
     largestSegmentId: Optional[int] = None
 
     def __post_init__(self) -> None:

--- a/wkconnect/backends/neuroglancer/sharding.py
+++ b/wkconnect/backends/neuroglancer/sharding.py
@@ -1,7 +1,7 @@
 import gzip
 import math
 from dataclasses import dataclass, field
-from typing import Optional, Tuple, Any
+from typing import Any, Optional, Tuple
 
 import numpy as np
 

--- a/wkconnect/backends/neuroglancer/sharding.py
+++ b/wkconnect/backends/neuroglancer/sharding.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 import numpy as np
 
 from ...utils.types import Vec3D
+from .mmh3 import hash64
 
 
 def compressed_morton_code(pos: Vec3D, grid_size: Vec3D) -> np.uint64:
@@ -90,9 +91,6 @@ class ShardingInfo:
     _minishard_mask: np.uint64 = field(init=False)
 
     def __post_init__(self) -> None:
-        assert (
-            self.hashfn == "identity"
-        ), "Only `identity` is currently supported and not `murmurhash3_x86_128`"
         # object.__setattr__ must be used to circumvent errors since the dataclass is frozen
         object.__setattr__(
             self,
@@ -114,10 +112,15 @@ class ShardingInfo:
     def format_shard_for_url(self, loc: MinishardInfo) -> str:
         return format(loc.shard_number, "x").zfill(int(np.ceil(self.shard_bits / 4.0)))
 
+    def hash_chunk_id(self, chunk_id: np.uint64) -> np.uint64:
+        if self.hashfn == "murmurhash3_x86_128":
+            return np.uint64(hash64(chunk_id.tobytes(), x64arch=False)[0])
+        elif self.hashfn == "identity":
+            return chunk_id
+
     def get_minishard_info(self, key: np.uint64) -> MinishardInfo:
         chunk_id = np.uint64(key) >> np.uint64(self.preshift_bits)
-        # Only `identity` hashfn is currently supported, so this is a no-op:
-        # chunk_id = hashfn(chunk_id)
+        chunk_id = self.hash_chunk_id(chunk_id)
         minishard_number = np.uint64(chunk_id & self._minishard_mask)
         shard_number = np.uint64(
             (chunk_id & self._shard_mask) >> np.uint64(self.minishard_bits)

--- a/wkconnect/backends/tiff/models.py
+++ b/wkconnect/backends/tiff/models.py
@@ -8,8 +8,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 from tifffile import TiffFile, imread
 
-from wkconnect.utils.types import Vec3D, Vec3Df
-
+from ...utils.types import Vec3D, Vec3Df
 from ...webknossos.models import BoundingBox as WkBoundingBox
 from ...webknossos.models import DataLayer as WkDataLayer
 from ...webknossos.models import DataSource as WkDataSource

--- a/wkconnect/backends/wkw/backend.py
+++ b/wkconnect/backends/wkw/backend.py
@@ -1,12 +1,15 @@
+import gzip
 import logging
 from pathlib import Path
-from typing import Dict, Optional, cast
+from typing import Dict, List, Optional, cast
 
+import h5py
 import numpy as np
 from aiohttp import ClientSession
 from wkcuber.api.Dataset import WKDataset
 
 from ...fast_wkw import DatasetCache  # pylint: disable=no-name-in-module
+from ...utils.blocking import run_blocking
 from ...utils.types import JSON, Vec3D
 from ..backend import Backend, DatasetInfo
 from .models import Dataset
@@ -41,6 +44,85 @@ class Wkw(Backend):
     ) -> Optional[np.ndarray]:
         dataset = cast(Dataset, abstract_dataset)
         return await dataset.read_data(layer_name, zoom_step, wk_offset, shape)
+
+    async def get_meshes(
+        self, abstract_dataset: DatasetInfo, layer_name: str
+    ) -> Optional[List[str]]:
+        dataset = cast(Dataset, abstract_dataset)
+        assert (
+            layer_name in dataset.dataset_handle.layers
+        ), f"Layer {layer_name} does not exist"
+        meshes_folder = dataset.dataset_handle.path / layer_name / "meshes"
+        if meshes_folder.exists() and meshes_folder.is_dir:
+            mesh_paths = list(meshes_folder.glob("*.hdf5"))
+            return [mesh_path.name[:-5] for mesh_path in mesh_paths]
+        return []
+
+    async def get_chunks_for_mesh(
+        self,
+        abstract_dataset: DatasetInfo,
+        layer_name: str,
+        mesh_name: str,
+        segment_id: int,
+    ) -> Optional[List[Vec3D]]:
+        dataset = cast(Dataset, abstract_dataset)
+        assert (
+            layer_name in dataset.dataset_handle.layers
+        ), f"Layer {layer_name} does not exist"
+        meshes_folder = dataset.dataset_handle.path / layer_name / "meshes"
+        assert (
+            meshes_folder.exists() and meshes_folder.is_dir()
+        ), f"Mesh folder for layer {layer_name} does not exist"
+        mesh_path = meshes_folder / f"{mesh_name}.hdf5"
+        assert (
+            meshes_folder.exists()
+        ), f"Mesh {mesh_name} for layer {layer_name} does not exist"
+
+        def read_mesh(mesh_path: Path, segment_id: int) -> List[Vec3D]:
+            with h5py.File(mesh_path, "r") as mesh_file:
+                segment_group = mesh_file.get(str(segment_id), None)
+                if segment_group is None:
+                    return []
+                lod_group = segment_group["0"]
+                chunk_keys = [
+                    Vec3D(*[int(a) for a in chunk_key.split("_")])
+                    for chunk_key in lod_group.keys()
+                ]
+                return chunk_keys
+
+        return await run_blocking(read_mesh, mesh_path, segment_id)
+
+    async def get_chunk_data_for_mesh(
+        self,
+        abstract_dataset: DatasetInfo,
+        layer_name: str,
+        mesh_name: str,
+        segment_id: int,
+        position: Vec3D,
+    ) -> Optional[bytes]:
+        dataset = cast(Dataset, abstract_dataset)
+        assert (
+            layer_name in dataset.dataset_handle.layers
+        ), f"Layer {layer_name} does not exist"
+        meshes_folder = dataset.dataset_handle.path / layer_name / "meshes"
+        assert (
+            meshes_folder.exists() and meshes_folder.is_dir()
+        ), f"Mesh folder for layer {layer_name} does not exist"
+        mesh_path = meshes_folder / f"{mesh_name}.hdf5"
+        assert (
+            meshes_folder.exists()
+        ), f"Mesh {mesh_name} for layer {layer_name} does not exist"
+
+        def read_chunk(mesh_path: Path, segment_id: int, position: Vec3D) -> bytes:
+            with h5py.File(mesh_path, "r") as mesh_file:
+                chunk_key = f"{position[0]}_{position[1]}_{position[2]}"
+                mesh_encoding = mesh_file.attrs.get("metadata/encoding", "stl")
+                mesh_binary = mesh_file[f"/{segment_id}/0/{chunk_key}"][:].tobytes()
+                if mesh_encoding == "stl+gzip":
+                    mesh_binary = gzip.decompress(mesh_binary)
+                return mesh_binary
+
+        return await run_blocking(read_chunk, mesh_path, segment_id, position)
 
     def clear_dataset_cache(self, abstract_dataset: DatasetInfo) -> None:
         dataset = cast(Dataset, abstract_dataset)

--- a/wkconnect/backends/wkw/models.py
+++ b/wkconnect/backends/wkw/models.py
@@ -8,9 +8,8 @@ from wkcuber.api.Dataset import WKDataset
 from wkcuber.api.Properties.LayerProperties import LayerProperties
 from wkcuber.mag import Mag
 
-from wkconnect.utils.types import Vec3D, Vec3Df
-
 from ...fast_wkw import DatasetCache, DatasetHandle  # pylint: disable=no-name-in-module
+from ...utils.types import Vec3D, Vec3Df
 from ...webknossos.models import BoundingBox as WkBoundingBox
 from ...webknossos.models import DataLayer as WkDataLayer
 from ...webknossos.models import DataSource as WkDataSource

--- a/wkconnect/routes/datasets/meshes.py
+++ b/wkconnect/routes/datasets/meshes.py
@@ -17,7 +17,7 @@ async def get_meshes(
     )
 
     if backend_name == "neuroglancer":
-        if layer_name in dataset.layers and dataset.layers.mesh:
+        if layer_name in dataset.layers and dataset.layers[layer_name].mesh:
             return response.json(["mesh"])
 
     return response.json([])
@@ -70,4 +70,3 @@ async def get_mesh_chunk_data(
         return response.raw(chunk_data)
 
     return response.text("", 404)
-

--- a/wkconnect/routes/datasets/meshes.py
+++ b/wkconnect/routes/datasets/meshes.py
@@ -41,9 +41,10 @@ async def get_mesh_chunks(
     backend = request.app.ctx.backends[backend_name]
 
     segment_id = request_body["segmentId"]
+    mesh_name = request_body["meshFile"]
     try:
         chunks = await backend.get_chunks_for_mesh(
-            dataset, layer_name, "mesh", segment_id
+            dataset, layer_name, mesh_name, segment_id
         )
         if chunks is None:
             return response.empty(status=404)
@@ -67,11 +68,12 @@ async def get_mesh_chunk_data(
     )
     backend = request.app.ctx.backends[backend_name]
     segment_id = request_body["segmentId"]
+    mesh_name = request_body["meshFile"]
     position = Vec3D(*request_body["position"])
 
     try:
         chunk_data = await backend.get_chunk_data_for_mesh(
-            dataset, layer_name, "mesh", segment_id, position
+            dataset, layer_name, mesh_name, segment_id, position
         )
         if chunk_data is None:
             return response.empty(status=404)

--- a/wkconnect/routes/datasets/meshes.py
+++ b/wkconnect/routes/datasets/meshes.py
@@ -1,6 +1,8 @@
 from sanic import Blueprint, response
 from sanic.request import Request
 
+from wkconnect.utils.types import Vec3D
+
 meshes = Blueprint(__name__)
 
 
@@ -10,7 +12,62 @@ meshes = Blueprint(__name__)
 async def get_meshes(
     request: Request, organization_name: str, dataset_name: str, layer_name: str
 ) -> response.HTTPResponse:
-    del organization_name
-    del dataset_name
-    del layer_name
+    (backend_name, dataset) = request.app.ctx.repository.get_dataset(
+        organization_name, dataset_name
+    )
+
+    if backend_name == "neuroglancer":
+        if layer_name in dataset.layers and dataset.layers.mesh:
+            return response.json(["mesh"])
+
     return response.json([])
+
+
+@meshes.route(
+    "/<organization_name>/<dataset_name>/layers/<layer_name>/meshes/chunks",
+    methods=["POST"],
+)
+async def get_mesh_chunks(
+    request: Request, organization_name: str, dataset_name: str, layer_name: str
+) -> response.HTTPResponse:
+    request_body = request.json
+
+    (backend_name, dataset) = request.app.ctx.repository.get_dataset(
+        organization_name, dataset_name
+    )
+    backend = request.app.ctx.backends[backend_name]
+
+    if backend_name == "neuroglancer":
+        segment_id = request_body["segmentId"]
+        chunks = await backend.get_chunks_for_mesh(
+            dataset, layer_name, "mesh", segment_id
+        )
+        return response.json(chunks)
+
+    return response.json([])
+
+
+@meshes.route(
+    "/<organization_name>/<dataset_name>/layers/<layer_name>/meshes/chunks/data",
+    methods=["POST"],
+)
+async def get_mesh_chunk_data(
+    request: Request, organization_name: str, dataset_name: str, layer_name: str
+) -> response.HTTPResponse:
+    request_body = request.json
+
+    (backend_name, dataset) = request.app.ctx.repository.get_dataset(
+        organization_name, dataset_name
+    )
+    backend = request.app.ctx.backends[backend_name]
+
+    if backend_name == "neuroglancer":
+        segment_id = request_body["segmentId"]
+        position = Vec3D(*request_body["position"])
+        chunk_data = await backend.get_chunk_data_for_mesh(
+            dataset, layer_name, "mesh", segment_id, position
+        )
+        return response.raw(chunk_data)
+
+    return response.text("", 404)
+

--- a/wkconnect/routes/datasets/meshes.py
+++ b/wkconnect/routes/datasets/meshes.py
@@ -1,7 +1,8 @@
 from sanic import Blueprint, response
 from sanic.request import Request
 
-from wkconnect.utils.types import Vec3D
+from ...utils.types import Vec3D
+from ...webknossos.access import AccessRequest, authorized
 
 meshes = Blueprint(__name__)
 
@@ -9,6 +10,7 @@ meshes = Blueprint(__name__)
 @meshes.route(
     "/<organization_name>/<dataset_name>/layers/<layer_name>/meshes", methods=["GET"]
 )
+@authorized(AccessRequest.read_dataset)
 async def get_meshes(
     request: Request, organization_name: str, dataset_name: str, layer_name: str
 ) -> response.HTTPResponse:
@@ -27,6 +29,7 @@ async def get_meshes(
     "/<organization_name>/<dataset_name>/layers/<layer_name>/meshes/chunks",
     methods=["POST"],
 )
+@authorized(AccessRequest.read_dataset)
 async def get_mesh_chunks(
     request: Request, organization_name: str, dataset_name: str, layer_name: str
 ) -> response.HTTPResponse:
@@ -53,6 +56,7 @@ async def get_mesh_chunks(
     "/<organization_name>/<dataset_name>/layers/<layer_name>/meshes/chunks/data",
     methods=["POST"],
 )
+@authorized(AccessRequest.read_dataset)
 async def get_mesh_chunk_data(
     request: Request, organization_name: str, dataset_name: str, layer_name: str
 ) -> response.HTTPResponse:

--- a/wkconnect/utils/blocking.py
+++ b/wkconnect/utils/blocking.py
@@ -1,0 +1,19 @@
+from asyncio import get_running_loop
+from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache
+from typing import Any, Callable, TypeVar
+
+THREAD_POOL_MAX_WORKERS = 32
+_T = TypeVar("_T")
+
+
+@lru_cache()
+def get_thread_pool_executor() -> ThreadPoolExecutor:
+    return ThreadPoolExecutor(max_workers=THREAD_POOL_MAX_WORKERS)
+
+
+async def run_blocking(blocking_function: Callable[..., _T], *args: Any) -> _T:
+    executor = get_thread_pool_executor()
+    loop = get_running_loop()
+
+    return await loop.run_in_executor(executor, blocking_function, *args)


### PR DESCRIPTION
This PR adds support for fetching/parsing meshes in the [neuroglancer precomputed format](https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/meshes.md) and making it available for webKnossos using the standard mesh API. Since webKnossos doesn't support level-of-detail yet, the lod is hard-coded to 2 :D