### PR TITLE
Wkw meshes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -327,6 +327,17 @@ pyjwt = ">=1.5.3,<3.0.0"
 six = ">=1.11.0,<2.0.0"
 
 [[package]]
+name = "h5py"
+version = "3.6.0"
+description = "Read and write HDF5 files from Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = ">=1.14.5"
+
+[[package]]
 name = "httptools"
 version = "0.2.0"
 description = "A collection of framework independent HTTP protocol utils."
@@ -1047,7 +1058,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "15b1943172fee2204845bd816dc188e2165f6b82429c2d1e5a0ad130692efd62"
+content-hash = "a4accc60b1744865bd9ca043a4130ed675c0829dfc1f8ecd7de253604bdff259"
 
 [metadata.files]
 aiofiles = [
@@ -1366,6 +1377,24 @@ future = [
 gcloud-aio-auth = [
     {file = "gcloud-aio-auth-3.6.0.tar.gz", hash = "sha256:0085a8b6539c9cf6fab514349b9e20e9628299e1766adc8dccd14ccb142bba28"},
     {file = "gcloud_aio_auth-3.6.0-py2.py3-none-any.whl", hash = "sha256:623ca19a8d1b3493bd31ea660d242c8c43f541f170a7ebc710869392cbeada2a"},
+]
+h5py = [
+    {file = "h5py-3.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a5320837c60870911645e9a935099bdb2be6a786fcf0dac5c860f3b679e2de55"},
+    {file = "h5py-3.6.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98646e659bf8591a2177e12a4461dced2cad72da0ba4247643fd118db88880d2"},
+    {file = "h5py-3.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:5996ff5adefd2d68c330a4265b6ef92e51b2fc674834a5990add5033bf109e20"},
+    {file = "h5py-3.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c9a5529343a619fea777b7caa27d493595b28b5af8b005e8d1817559fcccf493"},
+    {file = "h5py-3.6.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e2b49c48df05e19bb20b400b7ff7dc6f1ee36b84dc717c3771c468b33697b466"},
+    {file = "h5py-3.6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd9447633b0bafaf82190d9a8d56f3cb2e8d30169483aee67d800816e028190a"},
+    {file = "h5py-3.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1c5acc660c458421e88c4c5fe092ce15923adfac4c732af1ac4fced683a5ea97"},
+    {file = "h5py-3.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:35ab552c6f0a93365b3cb5664a5305f3920daa0a43deb5b2c547c52815ec46b9"},
+    {file = "h5py-3.6.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:542781d50e1182b8fb619b1265dfe1c765e18215f818b0ab28b2983c28471325"},
+    {file = "h5py-3.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f39242960b8d7f86f3056cc2546aa3047ff4835985f6483229af8f029e9c8db"},
+    {file = "h5py-3.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ecedf16c613973622a334701f67edcc0249469f9daa0576e994fb20ac0405db"},
+    {file = "h5py-3.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d8cacad89aa7daf3626fce106f7f2662ac35b14849df22d252d0d8fab9dc1c0b"},
+    {file = "h5py-3.6.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dbaa1ed9768bf9ff04af0919acc55746e62b28333644f0251f38768313f31745"},
+    {file = "h5py-3.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:954c5c39a09b5302f69f752c3bbf165d368a65c8d200f7d5655e0fa6368a75e6"},
+    {file = "h5py-3.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:9fd8a14236fdd092a20c0bdf25c3aba3777718d266fabb0fdded4fcf252d1630"},
+    {file = "h5py-3.6.0.tar.gz", hash = "sha256:8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29"},
 ]
 httptools = [
     {file = "httptools-0.2.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:79dbc21f3612a78b28384e989b21872e2e3cf3968532601544696e4ed0007ce5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ tifffile = "^2020.9.3"
 wkcuber = "^0.5"
 DracoPy = "^0.0.19"
 numpy-stl = "^2.16.3"
+h5py = "^3.6.0"
 
 [tool.poetry.dev-dependencies]
 autoflake = "*"

--- a/wkconnect/backends/wkw/backend.py
+++ b/wkconnect/backends/wkw/backend.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, Optional, cast
+from typing import Dict, List, Optional, cast
 
 import numpy as np
 from aiohttp import ClientSession
@@ -41,6 +41,64 @@ class Wkw(Backend):
     ) -> Optional[np.ndarray]:
         dataset = cast(Dataset, abstract_dataset)
         return await dataset.read_data(layer_name, zoom_step, wk_offset, shape)
+
+    async def get_meshes(
+        self, abstract_dataset: DatasetInfo, layer_name: str
+    ) -> Optional[List[str]]:
+        dataset = cast(Dataset, abstract_dataset)
+        assert (
+            layer_name in dataset.dataset_handle.layers
+        ), f"Layer {layer_name} does not exist"
+        meshes_folder = dataset.dataset_handle.path / layer_name / "meshes"
+        if meshes_folder.exists() and meshes_folder.is_dir:
+            mesh_paths = list(meshes_folder.glob("*.hdf5"))
+            return [mesh_path.name[-6] for mesh_path in mesh_paths]
+        return []
+
+    async def get_chunks_for_mesh(
+        self,
+        abstract_dataset: DatasetInfo,
+        layer_name: str,
+        mesh_name: str,
+        segment_id: int,
+    ) -> Optional[List[Vec3D]]:
+        dataset = cast(Dataset, abstract_dataset)
+        assert (
+            layer_name in dataset.dataset_handle.layers
+        ), f"Layer {layer_name} does not exist"
+        meshes_folder = dataset.dataset_handle.path / layer_name / "meshes"
+        assert (
+            meshes_folder.exists() and meshes_folder.is_dir()
+        ), f"Mesh folder for layer {layer_name} does not exist"
+        mesh_path = meshes_folder / f"{mesh_name}.hdf5"
+        assert (
+            meshes_folder.exists()
+        ), f"Mesh {mesh_name} for layer {layer_name} does not exist"
+
+        raise NotImplementedError()
+
+    async def get_chunk_data_for_mesh(
+        self,
+        abstract_dataset: DatasetInfo,
+        layer_name: str,
+        mesh_name: str,
+        segment_id: int,
+        position: Vec3D,
+    ) -> Optional[bytes]:
+        dataset = cast(Dataset, abstract_dataset)
+        assert (
+            layer_name in dataset.dataset_handle.layers
+        ), f"Layer {layer_name} does not exist"
+        meshes_folder = dataset.dataset_handle.path / layer_name / "meshes"
+        assert (
+            meshes_folder.exists() and meshes_folder.is_dir()
+        ), f"Mesh folder for layer {layer_name} does not exist"
+        mesh_path = meshes_folder / f"{mesh_name}.hdf5"
+        assert (
+            meshes_folder.exists()
+        ), f"Mesh {mesh_name} for layer {layer_name} does not exist"
+
+        raise NotImplementedError()
 
     def clear_dataset_cache(self, abstract_dataset: DatasetInfo) -> None:
         dataset = cast(Dataset, abstract_dataset)

--- a/wkconnect/backends/wkw/backend.py
+++ b/wkconnect/backends/wkw/backend.py
@@ -8,9 +8,8 @@ import numpy as np
 from aiohttp import ClientSession
 from wkcuber.api.Dataset import WKDataset
 
-from wkconnect.utils.blocking import run_blocking
-
 from ...fast_wkw import DatasetCache  # pylint: disable=no-name-in-module
+from ...utils.blocking import run_blocking
 from ...utils.types import JSON, Vec3D
 from ..backend import Backend, DatasetInfo
 from .models import Dataset

--- a/wkconnect/routes/datasets/meshes.py
+++ b/wkconnect/routes/datasets/meshes.py
@@ -41,9 +41,10 @@ async def get_mesh_chunks(
     backend = request.app.ctx.backends[backend_name]
 
     segment_id = request_body["segmentId"]
+    mesh_name = request_body["meshFile"]
     try:
         chunks = await backend.get_chunks_for_mesh(
-            dataset, layer_name, "mesh", segment_id
+            dataset, layer_name, mesh_name, segment_id
         )
         if chunks is None:
             return response.empty(status=404)
@@ -67,11 +68,12 @@ async def get_mesh_chunk_data(
     )
     backend = request.app.ctx.backends[backend_name]
     segment_id = request_body["segmentId"]
+    mesh_name = request_body["meshFile"]
     position = Vec3D(*request_body["position"])
 
     try:
         chunk_data = await backend.get_chunk_data_for_mesh(
-            dataset, layer_name, "mesh", segment_id, position
+            dataset, layer_name, mesh_name, segment_id, position
         )
         if chunk_data is None:
             return response.empty(status=404)

--- a/wkconnect/utils/blocking.py
+++ b/wkconnect/utils/blocking.py
@@ -1,0 +1,19 @@
+from asyncio import get_running_loop
+from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache
+from typing import Any, Callable, TypeVar
+
+THREAD_POOL_MAX_WORKERS = 32
+_T = TypeVar("_T")
+
+
+@lru_cache()
+def get_thread_pool_executor() -> ThreadPoolExecutor:
+    return ThreadPoolExecutor(max_workers=THREAD_POOL_MAX_WORKERS)
+
+
+async def run_blocking(blocking_function: Callable[..., _T], *args: Any) -> _T:
+    executor = get_thread_pool_executor()
+    loop = get_running_loop()
+
+    return await loop.run_in_executor(executor, blocking_function, *args)


### PR DESCRIPTION
This PR builds upon the #120 PR and adds support for the wk-meshes in hdf5 format.

Since the `h5py` library only has a synchronous API, calls to `h5py` are wrapped and executed in a thread pool executor. See `wkconnect/utils/blocking.py`. Not sure, if the typing can be improved with generics (cc @jstriebel).