### PR TITLE
Add (empty) connectome route for compatibility

### DIFF
--- a/wkconnect/routes/datasets/__init__.py
+++ b/wkconnect/routes/datasets/__init__.py
@@ -1,5 +1,6 @@
 from sanic import Blueprint
 
+from .connectomes import connectomes
 from .datasource_properties import datasource_properties
 from .histogram import histogram
 from .meshes import meshes
@@ -14,5 +15,6 @@ datasets = Blueprint.group(
     histogram,
     upload,
     meshes,
+    connectomes,
     url_prefix="/datasets",
 )

--- a/wkconnect/routes/datasets/connectomes.py
+++ b/wkconnect/routes/datasets/connectomes.py
@@ -1,0 +1,17 @@
+from sanic import Blueprint, response
+from sanic.request import Request
+
+connectomes = Blueprint(__name__)
+
+
+@connectomes.route(
+    "/<organization_name>/<dataset_name>/layers/<layer_name>/connectomes",
+    methods=["GET"],
+)
+async def get_connectomes(
+    request: Request, organization_name: str, dataset_name: str, layer_name: str
+) -> response.HTTPResponse:
+    del organization_name
+    del dataset_name
+    del layer_name
+    return response.json([])


### PR DESCRIPTION
Adapt to new expected route added in https://github.com/scalableminds/webknossos/pull/5894
returning empty list always, as webknossos-connect does not support reading connectome files