### PR TITLE
Adapt to wk-datastore api version 2.0 (mag replaces zoomStep), thumbnail.jpg

### DIFF
--- a/wkconnect/__main__.py
+++ b/wkconnect/__main__.py
@@ -184,7 +184,7 @@ async def build_info(request: Request) -> response.HTTPResponse:
             "webknossosDatastore": {
                 "name": "webknossos-connect",
                 "version": "0.1",
-                "datastoreApiVersion": "1.0",
+                "datastoreApiVersion": "2.0",
             }
         }
     )

--- a/wkconnect/backends/backend.py
+++ b/wkconnect/backends/backend.py
@@ -37,7 +37,7 @@ class Backend(metaclass=ABCMeta):
         self,
         dataset: DatasetInfo,
         layer_name: str,
-        zoom_step: int,
+        mag: Vec3D,
         wk_offset: Vec3D,
         shape: Vec3D,
     ) -> Optional[np.ndarray]:
@@ -46,7 +46,7 @@ class Backend(metaclass=ABCMeta):
 
         :param dataset:
         :param layer_name:
-        :param zoomStep: 2^zoomStep is the smallest dimension of the scale
+        :param mag:
         :param wk_offset: in wk voxels
         :param shape: in scale voxels
         :returns: numpy array of shape shape

--- a/wkconnect/backends/neuroglancer/backend.py
+++ b/wkconnect/backends/neuroglancer/backend.py
@@ -348,16 +348,14 @@ class Neuroglancer(Backend):
         self,
         abstract_dataset: DatasetInfo,
         layer_name: str,
-        zoom_step: int,
+        mag: Vec3D,
         wk_offset: Vec3D,
         shape: Vec3D,
     ) -> Optional[np.ndarray]:
         dataset = cast(Dataset, abstract_dataset)
         layer = dataset.layers[layer_name]
-        # we can use zoom_step as the index, as the scales are sorted
-        # see assertion in the Layer initialization
         scale = [
-            scale for scale in layer.scales if 2 ** zoom_step == scale.mag.as_np().max()
+            scale for scale in layer.scales if mag.max_dim() == scale.mag.as_np().max()
         ][0]
         decoder = self.decoders[scale.encoding]
 

--- a/wkconnect/backends/tiff/backend.py
+++ b/wkconnect/backends/tiff/backend.py
@@ -39,12 +39,12 @@ class Tiff(Backend):
         self,
         abstract_dataset: DatasetInfo,
         layer_name: str,
-        zoom_step: int,
+        mag: Vec3D,
         wk_offset: Vec3D,
         shape: Vec3D,
     ) -> Optional[np.ndarray]:
         dataset = cast(Dataset, abstract_dataset)
-        return dataset.read_data(layer_name, zoom_step, wk_offset, shape)
+        return dataset.read_data(layer_name, mag, wk_offset, shape)
 
     def clear_dataset_cache(self, abstract_dataset: DatasetInfo) -> None:
         dataset = cast(Dataset, abstract_dataset)

--- a/wkconnect/backends/wkw/backend.py
+++ b/wkconnect/backends/wkw/backend.py
@@ -38,12 +38,12 @@ class Wkw(Backend):
         self,
         abstract_dataset: DatasetInfo,
         layer_name: str,
-        zoom_step: int,
+        mag: Vec3D,
         wk_offset: Vec3D,
         shape: Vec3D,
     ) -> Optional[np.ndarray]:
         dataset = cast(Dataset, abstract_dataset)
-        return await dataset.read_data(layer_name, zoom_step, wk_offset, shape)
+        return await dataset.read_data(layer_name, mag, wk_offset, shape)
 
     async def get_meshes(
         self, abstract_dataset: DatasetInfo, layer_name: str

--- a/wkconnect/routes/datasets/read_data.py
+++ b/wkconnect/routes/datasets/read_data.py
@@ -46,7 +46,7 @@ async def get_data_post(
             backend.read_data(
                 dataset,
                 layer_name,
-                r.zoomStep,
+                Vec3D(*r.mag),
                 Vec3D(*r.position),
                 Vec3D(r.cubeSize, r.cubeSize, r.cubeSize),
             )

--- a/wkconnect/utils/types.py
+++ b/wkconnect/utils/types.py
@@ -52,6 +52,9 @@ class Vec3D(NamedTuple):
     def as_tuple(self) -> Tuple[int, int, int]:
         return (self.x, self.y, self.z)
 
+    def max_dim(self) -> int:
+        return max(max(self.x, self.y), self.z)
+
     @classmethod
     def zeros(cls) -> Vec3D:
         return cls(0, 0, 0)

--- a/wkconnect/webknossos/models.py
+++ b/wkconnect/webknossos/models.py
@@ -15,7 +15,7 @@ class DataStoreStatus(NamedTuple):
 
 class DataRequest(NamedTuple):
     position: Vec3D
-    zoomStep: int
+    mag: Vec3D
     cubeSize: int
     fourBit: bool
 


### PR DESCRIPTION
The webKnossos datastore API changes in https://github.com/scalableminds/webknossos/pull/6159
 - thumbnail.json is removed (thus we implement thumbnail.jpg here now)
 - zoomStep is replaced by mag in data requests
 - bump api version to 2.0

I used Vec3D rather than Mag as it was the smaller change (and Mag is not hashable for caching). Note that in https://github.com/scalableminds/webknossos-connect/issues/117 we want to replace both by the Mag from wk-libs anyway.