### PR TITLE
remove uint64->uint32 conversion

### DIFF
--- a/wkconnect/routes/datasets/read_data.py
+++ b/wkconnect/routes/datasets/read_data.py
@@ -21,8 +21,6 @@ def convert_data(to_four_bit: bool, data: np.ndarray) -> np.ndarray:
         odds = data[::2]
         evens = data[1::2]
         return ((odds >> 4) << 4) | (evens >> 4)
-    elif data.dtype == np.dtype("uint64"):
-        return (data & np.uint64(0xFFFFFFFF)).astype("uint32")
     else:
         return data
 


### PR DESCRIPTION
Since we are now supporting uin64 (or sth. like uint53^^) in the frontend, we can and should send the whole data to it.

~~I'm not :100:% sure, how the datasource is handled in the different use-cases, but I think it was already presented as a uint64 dataset there, and the conversion just happened in the single place changed in this PR. I'll double check this.~~

The only place where uint64 was converted is the one in this change. In the datasource-properties the layer was already presented as uint64.

@fm3 @philippotto Would it be easy for you to test this change locally?